### PR TITLE
Correct the method called on doctrine configuration class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "doctrine/migrations": "~1.0.0",
+    "doctrine/migrations": "~1.1.0",
     "illuminate/contracts": "~5.1",
     "illuminate/console": "~5.1",
     "illuminate/support": "~5.1",

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -50,7 +50,7 @@ class ConfigurationFactory
             $this->config->get('migrations.naming_strategy', DefaultNamingStrategy::class)
         ));
 
-        $configuration->setMigrationFinder($configuration->getNamingStrategy()->getFinder());
+        $configuration->setMigrationsFinder($configuration->getNamingStrategy()->getFinder());
 
         $directory = $this->config->get('migrations.directory', database_path('migrations'));
         $configuration->setMigrationsDirectory($directory);


### PR DESCRIPTION
This wasn't working for me at all, looks like the correct method has an 's' in it as you can see here:

https://github.com/doctrine/migrations/blob/master/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php#L333
