### PR TITLE
Add force argument to migrate command

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -24,7 +24,8 @@ class MigrateCommand extends Command
     {--connection= : For a specific connection }
     {--write-sql= : The path to output the migration SQL file instead of executing it. }
     {--dry-run= : Execute the migration as a dry run. }
-    {--query-time= : Time all the queries individually. }';
+    {--query-time= : Time all the queries individually. }
+    {--force : Force the operation to run when in production. }';
 
     /**
      * @var string


### PR DESCRIPTION
Running migration command in production was throwing an 'InvalidArgumentException' with message 'The "force" option does not exist.'
