### PR TITLE
Fix for migration rollback command

### DIFF
--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -14,7 +14,8 @@ class RollbackCommand extends Command
      * The name and signature of the console command.
      * @var string
      */
-    protected $signature = 'doctrine:migrations:rollback [version=]
+    protected $signature = 'doctrine:migrations:rollback
+    {--migration-version= : For a specific migration version.}
     {--connection= : For a specific connection.}';
 
     /**
@@ -33,10 +34,11 @@ class RollbackCommand extends Command
             $this->option('connection')
         );
 
-        $version = $this->argument('version') ?: $configuration->getCurrentVersion();
+        $version = $this->option('migration-version') ?: $configuration->getCurrentVersion();
 
         if ($version == 0) {
-            return $this->error('No migrations to be rollbacked');
+            $this->error('No migrations to be rollbacked');
+            return;
         }
 
         $this->call('doctrine:migrations:execute', [

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -38,6 +38,7 @@ class RollbackCommand extends Command
 
         if ($version == 0) {
             $this->error('No migrations to be rollbacked');
+
             return;
         }
 


### PR DESCRIPTION
## The problem

The `php artisan doctrine:migrations:rollback` doesn't work. When executed without arguments it throws `InvalidArgumentException: The "version" argument does not exist.`. When executed with an argument it throws `[RuntimeException]: Too many arguments.`
## The fix

Updated the $signature property of `LaravelDoctrine\Migrations\Console\RollbackCommand` from:

``` php
protected $signature = 'doctrine:migrations:rollback [version=]
    {--connection= : For a specific connection.}';
```

To:

``` php
protected $signature = 'doctrine:migrations:rollback
    {--migration-version= : For a specific migration version.}
    {--connection= : For a specific connection.}';
```

Also updated the line 36 from:

``` php
$version = $this->argument('version') ?: $configuration->getCurrentVersion();
```

to:

``` php
$version = $this->option('migration-version') ?: $configuration->getCurrentVersion();
```

With these changes the command accepts no argument and the rollback is executed to the latest version. When the `--migration-version` option is passed, the rollback is executed to that specific migration version.
