### PR TITLE
Added length option to Table::binary. It defaults to 255

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -423,9 +423,9 @@ class Table
      *
      * @return \Doctrine\DBAL\Schema\Column
      */
-    public function binary($column)
+    public function binary($column, $length = 255)
     {
-        return $this->table->addColumn($column, Type::BINARY)->setNotnull(false);
+        return $this->table->addColumn($column, Type::BINARY, compact('length'))->setNotnull(false);
     }
 
     /**

--- a/tests/Schema/SchemaTableTest.php
+++ b/tests/Schema/SchemaTableTest.php
@@ -273,7 +273,7 @@ class SchemaTableTest extends PHPUnit_Framework_TestCase
     public function test_binary()
     {
         $column = m::mock(Column::class);
-        $this->dbal->shouldReceive('addColumn')->with('column', 'binary')->andReturn($column);
+        $this->dbal->shouldReceive('addColumn')->with('column', 'binary', ['length' => 255])->andReturn($column);
         $column->shouldReceive('setNotnull')->with(false)->once();
         $this->table->binary('column');
     }


### PR DESCRIPTION
Added length option to Table::binary. It defaults to 255 as Doctrine 2 points.

In order to be conformed with Laravel Migrations 5.1, and keep BC, this argument is optional.

References:
http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/latest/reference/schema-representation.html#portable-options
https://laravel.com/docs/5.1/migrations
#18 Related Issue
