### PR TITLE
Support for DatabaseMigration for Testing

### DIFF
--- a/src/Testing/DatabaseMigrations.php
+++ b/src/Testing/DatabaseMigrations.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaravelDoctrine\Migrations\Testing;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait DatabaseMigrations
+{
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @return void
+     */
+    public function runDatabaseMigrations()
+    {
+        $this->artisan('doctrine:migrations:migrate');
+
+        $this->app[Kernel::class]->setArtisan(null);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('doctrine:migrations:rollback');
+        });
+    }
+}


### PR DESCRIPTION
This PR is created because I can't use `Illuminate\Foundation\Testing\DatabaseMigrations` with doctrine in functional test.

If we take a look to the code, it just execute eloquent migrations.  I create this trait in order to able migrate doctrine migrations.

``` php
<?php

use LaravelDoctrine\Migrations\Testing\DatabaseMigrations;

class AFeatureTest extends TestCase
{
   use DatabaseMigrations;
}

```
