### PR TITLE
Don't require a value for --dry-run flag. Fixes #30

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -23,7 +23,7 @@ class MigrateCommand extends Command
     {version=latest : The version number (YYYYMMDDHHMMSS) or alias (first, prev, next, latest) to migrate to.}
     {--connection= : For a specific connection }
     {--write-sql= : The path to output the migration SQL file instead of executing it. }
-    {--dry-run= : Execute the migration as a dry run. }
+    {--dry-run : Execute the migration as a dry run. }
     {--query-time= : Time all the queries individually. }
     {--force : Force the operation to run when in production. }';
 


### PR DESCRIPTION
By removing the `=` sign the `--dry-run` flag will always invoke a dry run and thus you don't need to explicitly set it to `true`.