### PR TITLE
Fixed typo in migrations config.

### DIFF
--- a/config/migrations.php
+++ b/config/migrations.php
@@ -31,7 +31,7 @@ return [
         |--------------------------------------------------------------------------
         |
         | This directory is where all migrations will be stored for this entity
-        | manager. User different directories for each entity manager.
+        | manager. Use different directories for each entity manager.
         |
         */
         'directory' => database_path('migrations'),


### PR DESCRIPTION
There is a typo error in config/migrations.php line 34 

> User different directories for each entity manager.

It has been updated to "Use different directories for each entity manager."