### PR TITLE
php artisan doctrine:migrations:migrate --write-sql throws ErrorException

### DIFF
--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -50,7 +50,8 @@ class Migrator
     {
         $path = is_bool($path) ? getcwd() : $path;
 
-        $sql = $migration->getMigration()->writeSqlFile($path, $migration->getVersion());
+        $sql = $migration->getMigration()->getSql($migration->getVersion());
+        $migration->getMigration()->writeSqlFile($path, $migration->getVersion());
 
         $this->writeNotes($migration, false, $sql);
     }


### PR DESCRIPTION
  [ErrorException]
  Invalid argument supplied for foreach()

This happens as a result of the return from $sqlWriter->write which returns the result from file_put_contents. file_put_contents returns the number of bytes that were written to the file, or FALSE on failure. writeNotes expects an array of statements which needs to be looked up separately.