### PR TITLE
Return exit code 1 when migration is cancelled

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -101,7 +101,7 @@ class MigrateCommand extends Command
 
         if (!$this->confirm('Are you sure you wish to continue?')) {
             $this->error('Migration cancelled!');
-            die;
+            exit(1);
         }
     }
 }


### PR DESCRIPTION
This is what doctrine does in the [same situation](https://github.com/doctrine/migrations/blob/master/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php#L125).

Should maybe concider returning 1 if cancelled here too: https://github.com/laravel-doctrine/migrations/blob/1.1/src/Console/MigrateCommand.php#L47 