### PR TITLE
rename fire method to handle in commands

### DIFF
--- a/src/Console/DiffCommand.php
+++ b/src/Console/DiffCommand.php
@@ -33,7 +33,7 @@ class DiffCommand extends Command
      * @param SqlBuilder             $builder
      * @param MigrationFileGenerator $generator
      */
-    public function fire(
+    public function handle(
         ConfigurationProvider $provider,
         ManagerRegistry $registry,
         SqlBuilder $builder,

--- a/src/Console/ExecuteCommand.php
+++ b/src/Console/ExecuteCommand.php
@@ -34,7 +34,7 @@ class ExecuteCommand extends Command
      * @param ConfigurationProvider $provider
      * @param Migrator              $migrator
      */
-    public function fire(ConfigurationProvider $provider, Migrator $migrator)
+    public function handle(ConfigurationProvider $provider, Migrator $migrator)
     {
         if (!$this->confirmToProceed()) {
             return;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -28,7 +28,7 @@ class GenerateCommand extends Command
      * @param ConfigurationProvider  $provider
      * @param MigrationFileGenerator $generator
      */
-    public function fire(ConfigurationProvider $provider, MigrationFileGenerator $generator)
+    public function handle(ConfigurationProvider $provider, MigrationFileGenerator $generator)
     {
         $configuration = $provider->getForConnection($this->option('connection'));
 

--- a/src/Console/LatestCommand.php
+++ b/src/Console/LatestCommand.php
@@ -24,7 +24,7 @@ class LatestCommand extends Command
      *
      * @param ConfigurationProvider $provider
      */
-    public function fire(ConfigurationProvider $provider)
+    public function handle(ConfigurationProvider $provider)
     {
         $configuration = $provider->getForConnection(
             $this->option('connection')

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -41,7 +41,7 @@ class MigrateCommand extends Command
      * @throws \Doctrine\DBAL\Migrations\MigrationException
      * @return int
      */
-    public function fire(ConfigurationProvider $provider, Migrator $migrator)
+    public function handle(ConfigurationProvider $provider, Migrator $migrator)
     {
         if (!$this->confirmToProceed()) {
             return;

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -24,7 +24,7 @@ class RefreshCommand extends Command
     /**
      * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         $this->call('doctrine:migrations:reset', [
             '--connection' => $this->option('connection')

--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -34,7 +34,7 @@ class ResetCommand extends Command
      *
      * @param ConfigurationProvider $provider
      */
-    public function fire(ConfigurationProvider $provider)
+    public function handle(ConfigurationProvider $provider)
     {
         $configuration = $provider->getForConnection(
             $this->option('connection')

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -27,7 +27,7 @@ class RollbackCommand extends Command
      *
      * @param ConfigurationProvider $provider
      */
-    public function fire(ConfigurationProvider $provider)
+    public function handle(ConfigurationProvider $provider)
     {
         $configuration = $provider->getForConnection(
             $this->option('connection')

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -26,7 +26,7 @@ class StatusCommand extends Command
      *
      * @param ConfigurationProvider $provider
      */
-    public function fire(ConfigurationProvider $provider)
+    public function handle(ConfigurationProvider $provider)
     {
         $configuration = $provider->getForConnection(
             $this->option('connection')

--- a/src/Console/VersionCommand.php
+++ b/src/Console/VersionCommand.php
@@ -42,7 +42,7 @@ class VersionCommand extends Command
      *
      * @param ConfigurationProvider $provider
      */
-    public function fire(ConfigurationProvider $provider)
+    public function handle(ConfigurationProvider $provider)
     {
         $this->configuration = $provider->getForConnection(
             $this->option('connection')


### PR DESCRIPTION
As per the upgrade guide of laravel 5.5, I renamed the `fire` method to `handle`.

> The `fire` Method
> Any `fire` methods present on your Artisan commands should be renamed to `handle`.

There should be no BC problems, the `handle` method is used from `laravel-5.0`.