### PR TITLE
Allow Lumen Publishing

### DIFF
--- a/src/MigrationsServiceProvider.php
+++ b/src/MigrationsServiceProvider.php
@@ -28,11 +28,9 @@ class MigrationsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (!$this->isLumen()) {
-            $this->publishes([
-                $this->getConfigPath() => config_path('migrations.php'),
-            ], 'config');
-        }
+        $this->publishes([
+            $this->getConfigPath() => config_path('migrations.php'),
+        ], 'config');
     }
 
     /**
@@ -65,7 +63,7 @@ class MigrationsServiceProvider extends ServiceProvider
         if ($this->isLumen()) {
             $this->app->configure('migrations');
         }
-           
+
         $this->mergeConfigFrom(
             $this->getConfigPath(), 'migrations'
         );


### PR DESCRIPTION
Allow publishing of the config files for lumen.

Publishing is easily enabled in lumen by just adding the VendorPublishCommand. However, this check currently prevents the publishing even though it works fine on lumen.

Signed-off-by: RJ Garcia <rj@bighead.net>