### PR TITLE
DatabaseMigrations check Kernel for existing method setArtisan

### DIFF
--- a/src/Testing/DatabaseMigrations.php
+++ b/src/Testing/DatabaseMigrations.php
@@ -13,9 +13,12 @@ trait DatabaseMigrations
      */
     public function runDatabaseMigrations()
     {
-        $this->artisan('doctrine:migrations:migrate');
+        $this->artisan('doctrine:migrations:refresh');
 
-        $this->app[Kernel::class]->setArtisan(null);
+        $kernel = $this->app[Kernel::class];
+        if (\method_exists($kernel, 'setArtisan')) {
+            $kernel->setArtisan(null);
+        }
 
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('doctrine:migrations:rollback');


### PR DESCRIPTION
To be compatible with Lumen.
Also changed the migrate command to refresh, because db inserts and deletes won't be affected by rollback and migrate.