### PR TITLE
Added allow-no-migration option to migrate command

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -25,7 +25,8 @@ class MigrateCommand extends Command
     {--write-sql= : The path to output the migration SQL file instead of executing it. }
     {--dry-run : Execute the migration as a dry run. }
     {--query-time= : Time all the queries individually. }
-    {--force : Force the operation to run when in production. }';
+    {--force : Force the operation to run when in production. }
+    {--allow-no-migration : Doesn\'t throw an exception if no migration is available. }';
 
     /**
      * @var string
@@ -72,7 +73,8 @@ class MigrateCommand extends Command
             $migrator->migrate(
                 $migration,
                 $this->option('dry-run') ? true : false,
-                $this->option('query-time') ? true : false
+                $this->option('query-time') ? true : false,
+                $this->option('allow-no-migration') ? true : false
             );
         }
 

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -15,9 +15,12 @@ class Migrator
      * @param Migration  $migration
      * @param bool|false $dryRun
      * @param bool|false $timeQueries
+     * @param bool|false $allowNoMigration
      */
-    public function migrate(Migration $migration, $dryRun = false, $timeQueries = false)
+    public function migrate(Migration $migration, $dryRun = false, $timeQueries = false, bool $allowNoMigration = false)
     {
+        $migration->getMigration()->setNoMigrationException($allowNoMigration);
+
         $sql = $migration->getMigration()->migrate(
             $migration->getVersion(),
             $dryRun,

--- a/tests/MigratorTest.php
+++ b/tests/MigratorTest.php
@@ -41,6 +41,7 @@ class MigratorTest extends PHPUnit_Framework_TestCase
         $this->dbalMig->shouldReceive('migrate')->with('version1', false, false)->andReturn([
             'version1' => 'SQL'
         ]);
+        $this->dbalMig->shouldReceive('setNoMigrationException')->with(false);
 
         $migrator = (new Migrator);
         $migrator->migrate($this->migration);


### PR DESCRIPTION
As requested in issue #77 I added the allow-no-migration option to the migrate command, as it exists in the doctrine/migrations migrate command.
It is an optional parameter in the migrate function of the migrator so it should not break any current implementations.