### PR TITLE
fixed --query-time option

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -24,7 +24,7 @@ class MigrateCommand extends Command
     {--connection= : For a specific connection }
     {--write-sql= : The path to output the migration SQL file instead of executing it. }
     {--dry-run : Execute the migration as a dry run. }
-    {--query-time= : Time all the queries individually. }
+    {--query-time : Time all the queries individually. }
     {--force : Force the operation to run when in production. }';
 
     /**


### PR DESCRIPTION
Changed the --query-time option for the migration command to not accept an input, as suggested in issue #61 . Now it is just an option flag.