### PR TITLE
Upgrade to PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.lock
 .idea
 laravel-doctrine-orm.iml
 phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "laravel-doctrine/orm": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.0",
-    "mockery/mockery": "~0.9"
+    "phpunit/phpunit": "^8.0",
+    "mockery/mockery": "~1.3"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -7,9 +7,13 @@ use LaravelDoctrine\Migrations\Configuration\Configuration;
 use LaravelDoctrine\Migrations\Configuration\ConfigurationFactory;
 use LaravelDoctrine\Migrations\Naming\DefaultNamingStrategy;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
+class ConfigurationFactoryTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var ConfigurationFactory
      */
@@ -35,7 +39,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
      */
     protected $configuration;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container     = m::mock(Container::class);
         $this->config        = m::mock(Repository::class);
@@ -162,11 +166,6 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('migrations', $configuration->getMigrationsTableName());
         $this->assertInstanceOf(DefaultNamingStrategy::class, $configuration->getNamingStrategy());
         $this->assertEquals(database_path('migrations'), $configuration->getMigrationsDirectory());
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }
 

--- a/tests/Configuration/ConfigurationProviderTest.php
+++ b/tests/Configuration/ConfigurationProviderTest.php
@@ -5,9 +5,13 @@ use Doctrine\DBAL\Connection;
 use LaravelDoctrine\Migrations\Configuration\ConfigurationFactory;
 use LaravelDoctrine\Migrations\Configuration\ConfigurationProvider;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationProviderTest extends PHPUnit_Framework_TestCase
+class ConfigurationProviderTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var ConfigurationProvider
      */
@@ -28,7 +32,7 @@ class ConfigurationProviderTest extends PHPUnit_Framework_TestCase
      */
     protected $connection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->registry   = m::mock(ManagerRegistry::class);
         $this->factory    = m::mock(ConfigurationFactory::class);
@@ -64,10 +68,5 @@ class ConfigurationProviderTest extends PHPUnit_Framework_TestCase
                         ->andReturn('configuration');
 
         $this->assertEquals('configuration', $this->provider->getForConnection('connection'));
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }

--- a/tests/MigrationTest.php
+++ b/tests/MigrationTest.php
@@ -5,15 +5,19 @@ use LaravelDoctrine\Migrations\Exceptions\ExecutedUnavailableMigrationsException
 use LaravelDoctrine\Migrations\Exceptions\MigrationVersionException;
 use LaravelDoctrine\Migrations\Migration;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class MigrationTest extends PHPUnit_Framework_TestCase
+class MigrationTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Mockery\Mock
      */
     protected $configuration;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = m::mock(Configuration::class);
         $this->configuration->shouldReceive('getOutputWriter');
@@ -52,7 +56,7 @@ class MigrationTest extends PHPUnit_Framework_TestCase
 
         ]);
 
-        $this->setExpectedException(ExecutedUnavailableMigrationsException::class);
+        $this->expectException(ExecutedUnavailableMigrationsException::class);
 
         $migration = new Migration(
             $this->configuration,
@@ -73,16 +77,11 @@ class MigrationTest extends PHPUnit_Framework_TestCase
             'version1'
         ]);
 
-        $this->setExpectedException(MigrationVersionException::class);
+        $this->expectException(MigrationVersionException::class);
 
         $migration = new Migration(
             $this->configuration,
             'latest'
         );
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }

--- a/tests/MigratorTest.php
+++ b/tests/MigratorTest.php
@@ -5,9 +5,13 @@ use LaravelDoctrine\Migrations\Configuration\Configuration;
 use LaravelDoctrine\Migrations\Migration;
 use LaravelDoctrine\Migrations\Migrator;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class MigratorTest extends PHPUnit_Framework_TestCase
+class MigratorTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Mockery\Mock
      */
@@ -23,7 +27,7 @@ class MigratorTest extends PHPUnit_Framework_TestCase
      */
     protected $dbalMig;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = m::mock(Configuration::class);
         $this->configuration->shouldReceive('getOutputWriter');
@@ -47,10 +51,5 @@ class MigratorTest extends PHPUnit_Framework_TestCase
         $migrator->migrate($this->migration);
 
         $this->assertContains('<info>Migrated:</info> version1', $migrator->getNotes());
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }

--- a/tests/Naming/DefaultNamingStrategyTest.php
+++ b/tests/Naming/DefaultNamingStrategyTest.php
@@ -2,8 +2,9 @@
 
 use Doctrine\DBAL\Migrations\Finder\RecursiveRegexFinder;
 use LaravelDoctrine\Migrations\Naming\DefaultNamingStrategy;
+use PHPUnit\Framework\TestCase;
 
-class DefaultNamingStrategyTest extends PHPUnit_Framework_TestCase
+class DefaultNamingStrategyTest extends TestCase
 {
     public function test_can_get_class_name()
     {

--- a/tests/Output/FileWriterTest.php
+++ b/tests/Output/FileWriterTest.php
@@ -1,17 +1,16 @@
 <?php
 
 use LaravelDoctrine\Migrations\Output\FileWriter;
+use PHPUnit\Framework\TestCase;
 
-class FileWriterTest extends PHPUnit_Framework_TestCase
+class FileWriterTest extends TestCase
 {
     public function test_can_write_to_non_existing_path()
     {
         $writer = new FileWriter;
 
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Migrations directory "doesntexist" does not exist.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Migrations directory "doesntexist" does not exist.');
 
         $writer->write('contents', 'filename.php', 'doesntexist');
     }

--- a/tests/Output/MigrationFileGeneratorTest.php
+++ b/tests/Output/MigrationFileGeneratorTest.php
@@ -7,9 +7,13 @@ use LaravelDoctrine\Migrations\Output\MigrationFileGenerator;
 use LaravelDoctrine\Migrations\Output\StubLocator;
 use LaravelDoctrine\Migrations\Output\VariableReplacer;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class MigrationFileGeneratorTest extends PHPUnit_Framework_TestCase
+class MigrationFileGeneratorTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var MigrationFileGenerator
      */
@@ -20,7 +24,7 @@ class MigrationFileGeneratorTest extends PHPUnit_Framework_TestCase
      */
     protected $configuration;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->generator = new MigrationFileGenerator(
             new StubLocator(),
@@ -53,11 +57,6 @@ class MigrationFileGeneratorTest extends PHPUnit_Framework_TestCase
         $filename = $this->generator->generate($this->configuration, false, 'users');
 
         $this->assertFileWasCreated($filename);
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 
     /**

--- a/tests/Output/SqlBuilderTest.php
+++ b/tests/Output/SqlBuilderTest.php
@@ -6,9 +6,13 @@ use Doctrine\DBAL\Schema\Schema;
 use LaravelDoctrine\Migrations\Configuration\Configuration;
 use LaravelDoctrine\Migrations\Output\SqlBuilder;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class SqlBuilderTest extends PHPUnit_Framework_TestCase
+class SqlBuilderTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Mockery\Mock
      */
@@ -39,7 +43,7 @@ class SqlBuilderTest extends PHPUnit_Framework_TestCase
      */
     protected $platform;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = m::mock(Configuration::class);
         $this->connection    = m::mock(Connection::class);
@@ -82,10 +86,5 @@ class SqlBuilderTest extends PHPUnit_Framework_TestCase
         $sql = $this->builder->down($this->configuration, $this->from, $this->to);
 
         $this->assertEquals(trim(file_get_contents(__DIR__ . '/../stubs/down.stub')), $sql);
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }

--- a/tests/Output/StubLocatorTest.php
+++ b/tests/Output/StubLocatorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use LaravelDoctrine\Migrations\Output\StubLocator;
+use PHPUnit\Framework\TestCase;
 
-class StubLocatorTest extends PHPUnit_Framework_TestCase
+class StubLocatorTest extends TestCase
 {
     public function test_can_get_a_stub()
     {

--- a/tests/Output/VariableReplacerTest.php
+++ b/tests/Output/VariableReplacerTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use LaravelDoctrine\Migrations\Output\VariableReplacer;
+use PHPUnit\Framework\TestCase;
 
-class VariableReplacerTest extends PHPUnit_Framework_TestCase
+class VariableReplacerTest extends TestCase
 {
     public function test_can_replace_variables()
     {

--- a/tests/Schema/SchemaBuilderTest.php
+++ b/tests/Schema/SchemaBuilderTest.php
@@ -4,9 +4,13 @@ use Doctrine\DBAL\Schema\Schema;
 use LaravelDoctrine\Migrations\Schema\Builder;
 use LaravelDoctrine\Migrations\Schema\Table;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class SchemaBuilderTest extends PHPUnit_Framework_TestCase
+class SchemaBuilderTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Mockery\Mock
      */
@@ -17,7 +21,7 @@ class SchemaBuilderTest extends PHPUnit_Framework_TestCase
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->schema  = m::mock(Schema::class);
         $this->builder = new Builder($this->schema);
@@ -135,10 +139,5 @@ class SchemaBuilderTest extends PHPUnit_Framework_TestCase
         $table->shouldReceive('getColumns')->once()->andReturn(['column' => 'instance']);
 
         $this->assertFalse($this->builder->hasColumns('table_name', ['column2']));
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }

--- a/tests/Schema/SchemaTableTest.php
+++ b/tests/Schema/SchemaTableTest.php
@@ -3,9 +3,13 @@
 use Doctrine\DBAL\Schema\Column;
 use LaravelDoctrine\Migrations\Schema\Table;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class SchemaTableTest extends PHPUnit_Framework_TestCase
+class SchemaTableTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Mockery\Mock
      */
@@ -16,7 +20,7 @@ class SchemaTableTest extends PHPUnit_Framework_TestCase
      */
     protected $table;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dbal  = m::mock(\Doctrine\DBAL\Schema\Table::class);
         $this->table = new Table($this->dbal);
@@ -304,10 +308,5 @@ class SchemaTableTest extends PHPUnit_Framework_TestCase
         $this->dbal->shouldReceive('dropColumn')->with('column');
 
         $this->table->dropColumn('column');
-    }
-
-    protected function tearDown()
-    {
-        m::close();
     }
 }


### PR DESCRIPTION
Get dependencies up to date to make the upgrade to doctrine migrations 2.0 easier.