### PR TITLE
Exposing new config value for migration version column length.

### DIFF
--- a/config/migrations.php
+++ b/config/migrations.php
@@ -74,6 +74,15 @@ return [
         */
         'schema'    => [
             'filter' => '/^(?!password_resets|failed_jobs).*$/'
-        ]
+        ],
+        /*
+        |--------------------------------------------------------------------------
+        | Migration Version Column Length
+        |--------------------------------------------------------------------------
+        |
+        | The length for the version column in the migrations table.
+        |
+        */
+        'version_column_length' => 14
     ],
 ];

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -75,6 +75,8 @@ class ConfigurationFactory
             }
         }
 
+        $configuration->setMigrationsColumnLength($config->get('version_column_length', 14));
+
         return $configuration;
     }
 }


### PR DESCRIPTION
This allows people to update the value to what they need. Length of `14` is what is default in `doctrine/migrations`.