### PR TITLE
Fix migrate command in --no-interaction mode

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -101,7 +101,7 @@ class MigrateCommand extends Command
             ));
         }
 
-        if (!$this->confirm('Are you sure you wish to continue?')) {
+        if ($this->input->isInteractive() && !$this->confirm('Are you sure you wish to continue?')) {
             $this->error('Migration cancelled!');
             exit(1);
         }


### PR DESCRIPTION
This PR fixes a bug when you are not able to run migrations using CI tools.

Steps to reproduce:
1. Dev 1 creates `awesome` from `master` branch and adds new migration
2. Dev 1 deploys `awesome` branch on staging server without merging it to `master` branch
3. Dev 2 creates branch `cool` from `master` branch and adds another one migration
4. Dev 2 cannot deploy `cool` branch on staging server because of exception

![Screenshot from 2020-10-21 23-37-12](https://user-images.githubusercontent.com/1849174/96787596-aff8c500-13fa-11eb-9da5-a3149438c082.png)

I've sent this PR to 1.x branch because using it currently.

Fixes #83 