### PR TITLE
Use laravel-doctrine/orm 2.0.x-dev for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "illuminate/config": "^8.0",
     "illuminate/contracts": "^8.0",
     "illuminate/console": "^8.0",
-    "laravel-doctrine/orm": "^1.7"
+    "laravel-doctrine/orm": "^2.0.x-dev"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
Currently it fails due to usage of ^1.7. With this version tests should be passing.