### PR TITLE
PHP8: Remove optional parameter in StatusCommand

### DIFF
--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -94,7 +94,7 @@ class StatusCommand extends Command
      * @param array         $migrations
      * @param Configuration $configuration
      */
-    protected function showVersions(array $migrations = [], Configuration $configuration)
+    protected function showVersions(array $migrations, Configuration $configuration)
     {
         $migratedVersions = $configuration->getMigratedVersions();
 


### PR DESCRIPTION
Firstly thanks to all authors for their work on these packages 🙌

Similar to the [work](https://github.com/laravel-doctrine/orm/pull/475) done in the `laravel-doctrine/orm` package, this merge fixes optional/required parameter ordering for PHP 8 compatibility.

Because it's in a protected method on a console command in this case, I've simply removed the optional parameter. It's used everywhere it's called.

Feel free to close this pull if this is something already being worked on - [I have seen a comment to that effect](https://github.com/laravel-doctrine/orm/pull/475#issuecomment-766661060)