### PR TITLE
Fix invalid optional parameter

### DIFF
--- a/src/Configuration/ConfigurationProvider.php
+++ b/src/Configuration/ConfigurationProvider.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\Migrations\Configuration;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 
 class ConfigurationProvider
 {

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -94,7 +94,7 @@ class StatusCommand extends Command
      * @param array         $migrations
      * @param Configuration $configuration
      */
-    protected function showVersions(array $migrations = [], Configuration $configuration)
+    protected function showVersions(array $migrations, Configuration $configuration)
     {
         $migratedVersions = $configuration->getMigratedVersions();
 


### PR DESCRIPTION
@eigan After composer update i got error:

```
 Required parameter $configuration follows optional parameter $migrations

  at /srv/vendor/laravel-doctrine/migrations/src/Console/StatusCommand.php:97
     93|     /**
     94|      * @param array         $migrations
     95|      * @param Configuration $configuration
     96|      */
  >  97|     protected function showVersions(array $migrations = [], Configuration $configuration)
     98|     {
     99|         $migratedVersions = $configuration->getMigratedVersions();
    100| 
    101|         foreach ($migrations as $version) {

```

This one should fix this