### PR TITLE
Updated the namespace of the ManagerRegistry

### DIFF
--- a/src/Configuration/ConfigurationProvider.php
+++ b/src/Configuration/ConfigurationProvider.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\Migrations\Configuration;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 
 class ConfigurationProvider
 {

--- a/src/Console/DiffCommand.php
+++ b/src/Console/DiffCommand.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\Migrations\Console;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Migrations\Provider\OrmSchemaProvider;
 use Doctrine\ORM\EntityManagerInterface;
 use Illuminate\Console\Command;

--- a/tests/Configuration/ConfigurationProviderTest.php
+++ b/tests/Configuration/ConfigurationProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use LaravelDoctrine\Migrations\Configuration\ConfigurationFactory;
 use LaravelDoctrine\Migrations\Configuration\ConfigurationProvider;


### PR DESCRIPTION
After running a `composer update`, the `DiffCommand` no longer works due to an update within the `doctrine/persistence` package - this PR address a simple namespace change.

I've noticed that a change I have made in my PR has already been done by someone else - I will rebase once that PR has been merged (https://github.com/laravel-doctrine/migrations/pull/109).