### PR TITLE
Added schema dump and rollup commands

### DIFF
--- a/src/Console/RollupCommand.php
+++ b/src/Console/RollupCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaravelDoctrine\Migrations\Console;
+
+use LaravelDoctrine\Migrations\Configuration\ConfigurationProvider;
+use LaravelDoctrine\Migrations\Rollup;
+use LaravelDoctrine\ORM\Console\Command;
+
+final class RollupCommand extends Command
+{
+    protected $signature = 'doctrine:migrations:rollup
+    {--connection= : For a specific connection. }
+    {--version-name= : A specific version gets marked as migrated. }';
+
+    public function handle(ConfigurationProvider $provider, Rollup $rollup): void
+    {
+        $version = $rollup->rollup(
+            $provider->getForConnection($this->option('connection')),
+            $this->option('version-name')
+        );
+
+        $this->line(\sprintf('Rolled up migrations to version <info>%s</info>', $version->getVersion()));
+    }
+}

--- a/src/Console/SchemaDumpCommand.php
+++ b/src/Console/SchemaDumpCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LaravelDoctrine\Migrations\Console;
+
+use LaravelDoctrine\Migrations\Configuration\ConfigurationProvider;
+use LaravelDoctrine\Migrations\SchemaDumper;
+use LaravelDoctrine\ORM\Console\Command;
+
+final class SchemaDumpCommand extends Command
+{
+    protected $signature = 'doctrine:migrations:dump-schema
+    {--connection= : For a specific connection. }
+    {--formatted : Format the generated SQL file. }
+    {--line-length=120 : Max line length of unformatted lines. }';
+
+    public function handle(ConfigurationProvider $provider, SchemaDumper $schemaDumper): void
+    {
+        $fileName = $schemaDumper->dump(
+            $provider->getForConnection($this->option('connection')),
+            $this->option('formatted'),
+            $this->option('line-length')
+        );
+
+        $this->line(\sprintf('Dumped schema to %s.', $fileName));
+    }
+}

--- a/src/MigrationsServiceProvider.php
+++ b/src/MigrationsServiceProvider.php
@@ -15,6 +15,7 @@ use LaravelDoctrine\Migrations\Console\MigrateCommand;
 use LaravelDoctrine\Migrations\Console\RefreshCommand;
 use LaravelDoctrine\Migrations\Console\ResetCommand;
 use LaravelDoctrine\Migrations\Console\RollbackCommand;
+use LaravelDoctrine\Migrations\Console\SchemaDumpCommand;
 use LaravelDoctrine\Migrations\Console\StatusCommand;
 use LaravelDoctrine\Migrations\Console\VersionCommand;
 
@@ -56,7 +57,8 @@ class MigrationsServiceProvider extends ServiceProvider
             VersionCommand::class,
             RefreshCommand::class,
             RollbackCommand::class,
-            GenerateCommand::class
+            GenerateCommand::class,
+            SchemaDumpCommand::class,
         ]);
     }
 

--- a/src/MigrationsServiceProvider.php
+++ b/src/MigrationsServiceProvider.php
@@ -15,6 +15,7 @@ use LaravelDoctrine\Migrations\Console\MigrateCommand;
 use LaravelDoctrine\Migrations\Console\RefreshCommand;
 use LaravelDoctrine\Migrations\Console\ResetCommand;
 use LaravelDoctrine\Migrations\Console\RollbackCommand;
+use LaravelDoctrine\Migrations\Console\RollupCommand;
 use LaravelDoctrine\Migrations\Console\SchemaDumpCommand;
 use LaravelDoctrine\Migrations\Console\StatusCommand;
 use LaravelDoctrine\Migrations\Console\VersionCommand;
@@ -59,6 +60,7 @@ class MigrationsServiceProvider extends ServiceProvider
             RollbackCommand::class,
             GenerateCommand::class,
             SchemaDumpCommand::class,
+            RollupCommand::class,
         ]);
     }
 

--- a/src/Rollup.php
+++ b/src/Rollup.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace LaravelDoctrine\Migrations;
+
+use Doctrine\Migrations\Exception\RollupFailed;
+use Doctrine\Migrations\Exception\UnknownMigrationVersion;
+use Doctrine\Migrations\Version\Version;
+use LaravelDoctrine\Migrations\Configuration\Configuration;
+
+final class Rollup
+{
+    public function rollup(Configuration $configuration, string $versionName = null): Version
+    {
+        $version = $this->getVersionToMarkMigrated($configuration, $versionName);
+
+        $configuration->getConnection()->executeQuery(
+            \sprintf('DELETE FROM %s', $configuration->getMigrationsTableName())
+        );
+
+        $version->markMigrated();
+
+        return $version;
+    }
+
+    private function getVersionToMarkMigrated(Configuration $configuration, string $versionName = null): Version
+    {
+        if (!empty($versionName)) {
+            try {
+                return $configuration->getDependencyFactory()->getMigrationRepository()->getVersion($versionName);
+            } catch (UnknownMigrationVersion $e) {
+                throw RollupFailed::noMigrationsFound();
+            }
+        }
+
+        $versions = $configuration->getDependencyFactory()->getMigrationRepository()->getVersions();
+        if (count($versions) === 0) {
+            throw RollupFailed::noMigrationsFound();
+        }
+        if (count($versions) > 1) {
+            throw RollupFailed::tooManyMigrations();
+        }
+
+        return \current($versions);
+    }
+}

--- a/src/SchemaDumper.php
+++ b/src/SchemaDumper.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace LaravelDoctrine\Migrations;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\Exception\NoTablesFound;
+use Doctrine\Migrations\Generator\SqlGenerator;
+use LaravelDoctrine\Migrations\Configuration\Configuration;
+use LaravelDoctrine\Migrations\Output\MigrationFileGenerator;
+
+final class SchemaDumper
+{
+    /**
+     * @var MigrationFileGenerator
+     */
+    private $migrationFileGenerator;
+
+    public function __construct(MigrationFileGenerator $migrationFileGenerator)
+    {
+        $this->migrationFileGenerator = $migrationFileGenerator;
+    }
+
+    public function dump(Configuration $configuration, bool $formatted = false, int $lineLength = 120): string
+    {
+        // The platform check and a skip if statement will be added by the SchemaDumper
+        $configuration->setCheckDatabasePlatform(false);
+
+        $platform = $configuration->getConnection()->getDatabasePlatform();
+        $migrationSqlGenerator = new SqlGenerator($configuration, $platform);
+
+        $up   = [];
+        $down = [];
+        foreach ($configuration->getConnection()->getSchemaManager()->createSchema()->getTables() as $table) {
+            $up = $this->addUpCodeForTable($up, $platform, $migrationSqlGenerator, $table, $formatted, $lineLength);
+            $down = $this->addDownCodeForTable($down, $platform, $migrationSqlGenerator, $table, $formatted, $lineLength);
+        }
+
+        if (count($up) === 0) {
+            throw NoTablesFound::new();
+        }
+
+        return $this->migrationFileGenerator->generate(
+            $configuration,
+            false,
+            false,
+            \implode("\n", $this->addPlatformCheck($up, $platform)),
+            \implode("\n", $this->addPlatformCheck($down, $platform))
+        );
+    }
+
+    private function addUpCodeForTable(
+        array $up,
+        AbstractPlatform $platform,
+        SqlGenerator $migrationSqlGenerator,
+        Table $table,
+        bool $formatted,
+        int $lineLength
+    ): array {
+        $upSql = $platform->getCreateTableSQL($table);
+
+        $upCode = $migrationSqlGenerator->generate(
+            $upSql,
+            $formatted,
+            $lineLength
+        );
+        if ($upCode !== '') {
+            $up[] = $upCode;
+        }
+
+        return $up;
+    }
+
+    private function addDownCodeForTable(
+        array $down,
+        AbstractPlatform $platform,
+        SqlGenerator $migrationSqlGenerator,
+        Table $table,
+        bool $formatted,
+        int $lineLength
+    ): array {
+        $downSql = [$platform->getDropTableSQL($table)];
+
+        $downCode = $migrationSqlGenerator->generate(
+            $downSql,
+            $formatted,
+            $lineLength
+        );
+        if ($downCode !== '') {
+            $down[] = $downCode;
+        }
+
+        return $down;
+    }
+
+    private function addPlatformCheck(array $statements, AbstractPlatform $platform): array
+    {
+        \array_unshift(
+            $statements,
+            \sprintf(
+                '$this->skipIf($this->connection->getDatabasePlatform()->getName() !== %s, %s);',
+                \var_export($platform->getName(), true),
+                \var_export(
+                    \sprintf("Migration can only be executed safely on '%s'.", $platform->getName()),
+                    true
+                )
+            ),
+        );
+
+        return $statements;
+    }
+}


### PR DESCRIPTION
I added a schema dump and rollup command like the commands already existing in Doctrine.
The commands work quite similar to the original Doctrine commands.
The schema dump writes create statements for every table like it is done in Doctrine but with the difference that I didn't use the `abortIf` method with the platform check but the `skipIf` method, so I am able to use different schema dumps for different connections/platforms.
The same goes for the rollup command. Here I added a `version-name` option, so I can have different migrations files for different connections and be able to just use one specific to mark as migrated.