### PR TITLE
Match doctrine/migrations command signature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+  pull_request:
 jobs:
   tests:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,35 @@
+name: "Static Analysis"
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  static-analysis-phpstan:
+    name: "Static Analysis with PHPStan"
+    runs-on: "ubuntu-22.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.0"
+          - "8.1"
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          extensions: "pdo_sqlite"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+
+      - name: "Run a static analysis with phpstan/phpstan"
+        run: "vendor/bin/phpstan analyse -c phpstan.neon.dist"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0 | ^8.3 | ^9.3",
-    "mockery/mockery": "^1.3.1",
     "phpstan/phpstan": "^1.9"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0 | ^8.3 | ^9.3",
-    "mockery/mockery": "^1.3.1"
+    "mockery/mockery": "^1.3.1",
+    "phpstan/phpstan": "^1.9"
   },
   "autoload": {
     "psr-4": {

--- a/config/migrations.php
+++ b/config/migrations.php
@@ -85,6 +85,6 @@ return [
         | The length for the version column in the migrations table.
         |
         */
-        'version_column_length' => 1024
+        'version_column_length' => 191
     ],
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,23 @@
+parameters:
+    level: 7
+    paths:
+        - src
+
+    ignoreErrors:
+        -
+            message: '~^Function config_path not found.$~'
+        -
+            message: '~^Function database_path not found.$~'
+
+        -
+            path: src/Console
+            message: '~^Parameter #1 \$name of method LaravelDoctrine\\Migrations\\Configuration\\DependencyFactoryProvider::fromEntityManagerName\(\)~'
+        -
+            path: src/Console
+            message: '~^Parameter #1 \$name of method LaravelDoctrine\\Migrations\\Configuration\\ConfigurationFactory::getConfigAsRepository\(\)~'
+        -
+            path: src/MigrationsServiceProvider.php
+            message: '~^Call to an undefined method Illuminate\\Contracts\\Foundation\\Application::configure\(\).~'
+        -
+            path: src/Configuration/DependencyFactoryProvider.php
+            message: '~^Parameter #1 \$entityManager of class Doctrine\\Migrations\\Configuration\\EntityManager\\ExistingEntityManager constructor expects Doctrine\\ORM\\EntityManagerInterface, Doctrine\\Persistence\\ObjectManager given.~'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
@@ -8,15 +9,16 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-        >
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Laravel Doctrine Migrations">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -41,7 +41,7 @@ class ConfigurationFactory
         return new ConfigurationArray([
             'table_storage' => [
                 'table_name' => $config->get('table', 'migrations'),
-                'version_column_length' => $config->get('version_column_length', 1024)
+                'version_column_length' => $config->get('version_column_length', 191)
             ],
             'migrations_paths' => [
                 $config->get('namespace', 'Database\\Migrations') => $config->get(

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -9,6 +9,9 @@ use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Container\Container;
 
+/**
+ * @internal
+ */
 class ConfigurationFactory
 {
     protected ConfigRepository $config;
@@ -21,6 +24,10 @@ class ConfigurationFactory
         $this->container = $container;
     }
 
+    /**
+     * @param string|null $name The EntityManager name
+     * @return array<string, mixed> The configuration (see config/migrations.php)
+     */
     public function getConfig(string $name = null): array
     {
         if ($name && $this->config->has('migrations.' . $name)) {
@@ -34,7 +41,7 @@ class ConfigurationFactory
         return new Repository($this->getConfig($name));
     }
 
-    public function make(string $name = null)
+    public function make(string $name = null): ConfigurationArray
     {
         $config = $this->getConfigAsRepository($name);
 

--- a/src/Configuration/DependencyFactoryProvider.php
+++ b/src/Configuration/DependencyFactoryProvider.php
@@ -22,16 +22,16 @@ class DependencyFactoryProvider
     }
 
     /**
-     * @param string|null $connectionName
+     * @param string|null $name
      *
      * @return DependencyFactory
      */
-    public function fromConnectionName(string $connectionName = null): DependencyFactory
+    public function fromEntityManagerName(string $name = null): DependencyFactory
     {
-        $configuration = $this->factory->make($connectionName);
+        $configuration = $this->factory->make($name);
         return DependencyFactory::fromEntityManager(
             $configuration,
-            new ExistingEntityManager($this->registry->getManager($connectionName))
+            new ExistingEntityManager($this->registry->getManager($name))
         );
     }
 }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -35,7 +35,7 @@ abstract class BaseCommand extends Command
         foreach ($definition->getOptions() as $option) {
             $optionName = $option->getName();
 
-            if ($optionName === 'connection' || !$this->optionExists($command, $optionName)) {
+            if ($optionName === 'em' || !$this->optionExists($command, $optionName)) {
                 continue;
             }
 

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -13,7 +13,7 @@ abstract class BaseCommand extends Command
 {
     /**
      * @param DoctrineCommand $command
-     * @return void
+     * @return ArrayInput
      */
     protected function getDoctrineInput(DoctrineCommand $command): ArrayInput
     {

--- a/src/Console/DiffCommand.php
+++ b/src/Console/DiffCommand.php
@@ -15,8 +15,14 @@ class DiffCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'doctrine:migrations:diff
-    {--connection= : For a specific connection }
-    {--filter-expression= : Tables which are filtered by Regular Expression.}';
+    {--em= : For a specific EntityManager. }
+    {--filter-expression= : Tables which are filtered by Regular Expression.}
+    {--formatted : Format the generated SQL. }
+    {--line-length=120 : Max line length of unformatted lines.} 
+    {--check-database-platform= : Check Database Platform to the generated code.}
+    {--allow-empty-diff : Do not throw an exception when no changes are detected. }
+    {--from-empty-schema : Generate a full migration as if the current database was empty. }
+    ';
 
     /**
      * @var string
@@ -32,14 +38,15 @@ class DiffCommand extends BaseCommand
         DependencyFactoryProvider               $provider,
         ConfigurationFactory                    $configurationFactory
     ): int {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
-        $migrationConfig = $configurationFactory->getConfigAsRepository($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
+        $migrationConfig = $configurationFactory->getConfigAsRepository($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\DiffCommand($dependencyFactory);
 
         if ($this->input->getOption('filter-expression') === null) {
             $this->input->setOption('filter-expression', $migrationConfig->get('schema.filter'));
         }
+
         try {
             return $command->run($this->getDoctrineInput($command), $this->output->getOutput());
         } catch (NoChangesDetected $exception) {

--- a/src/Console/ExecuteCommand.php
+++ b/src/Console/ExecuteCommand.php
@@ -13,8 +13,8 @@ class ExecuteCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'doctrine:migrations:execute {versions : The versions to execute }
-    {--connection= : For a specific connection.}
-    {--write-sql : The path to output the migration SQL file instead of executing it. }
+    {--em= : For a specific EntityManager. }
+    {--write-sql= : The path to output the migration SQL file instead of executing it. }
     {--dry-run : Execute the migration as a dry run. }
     {--up : Execute the migration up. }
     {--down : Execute the migration down. }
@@ -32,7 +32,7 @@ class ExecuteCommand extends BaseCommand
      */
     public function handle(DependencyFactoryProvider $provider): int
     {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\ExecuteCommand($dependencyFactory);
 

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -13,7 +13,7 @@ class GenerateCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'doctrine:migrations:generate
-    {--connection= : The entity manager connection to generate the migration for.}';
+    {--em= : For a specific EntityManager. }';
 
     /**
      * @var string
@@ -29,7 +29,7 @@ class GenerateCommand extends BaseCommand
      */
     public function handle(DependencyFactoryProvider $provider): int
     {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\GenerateCommand($dependencyFactory);
 

--- a/src/Console/LatestCommand.php
+++ b/src/Console/LatestCommand.php
@@ -13,7 +13,7 @@ class LatestCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'doctrine:migrations:latest
-    {--connection= : For a specific connection.}';
+    {--em= : For a specific EntityManager. }';
 
     /**
      * @var string
@@ -27,7 +27,7 @@ class LatestCommand extends BaseCommand
      */
     public function handle(DependencyFactoryProvider $provider): int
     {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\LatestCommand($dependencyFactory);
 

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -15,11 +15,13 @@ class MigrateCommand extends BaseCommand
      */
     protected $signature = 'doctrine:migrations:migrate
     {version=latest : The version number (YYYYMMDDHHMMSS) or alias (first, prev, next, latest) to migrate to.}
-    {--connection= : For a specific connection }
-    {--write-sql=/tmp : The path to output the migration SQL file instead of executing it. }
+    {--em= : For a specific EntityManager. }
+    {--write-sql= : The path to output the migration SQL file instead of executing it. }
     {--dry-run : Execute the migration as a dry run. }
     {--query-time : Time all the queries individually. }
-    {--allow-no-migration : Doesn\'t throw an exception if no migration is available. }';
+    {--allow-no-migration : Doesn\'t throw an exception if no migration is available. }
+    {--all-or-nothing= : Wrap the entire migration in a transaction. }
+    ';
 
     /**
      * @var string
@@ -35,7 +37,7 @@ class MigrateCommand extends BaseCommand
      */
     public function handle(DependencyFactoryProvider $provider): int
     {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\MigrateCommand($dependencyFactory);
 

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -23,13 +23,17 @@ class RefreshCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(): int
     {
-        $this->call('doctrine:migrations:reset', [
+        $resetReturn = $this->call('doctrine:migrations:reset', [
             '--em' => $this->option('em')
         ]);
 
-        $this->call('doctrine:migrations:migrate', [
+        if ($resetReturn !== 0) {
+            return 1;
+        }
+
+        return $this->call('doctrine:migrations:migrate', [
             '--em' => $this->option('em')
         ]);
     }

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -13,7 +13,7 @@ class RefreshCommand extends Command
      * @var string
      */
     protected $signature = 'doctrine:migrations:refresh
-    {--connection= : For a specific connection.}';
+    {--em= : For a specific EntityManager. }';
 
     /**
      * @var string
@@ -26,11 +26,11 @@ class RefreshCommand extends Command
     public function handle()
     {
         $this->call('doctrine:migrations:reset', [
-            '--connection' => $this->option('connection')
+            '--em' => $this->option('em')
         ]);
 
         $this->call('doctrine:migrations:migrate', [
-            '--connection' => $this->option('connection')
+            '--em' => $this->option('em')
         ]);
     }
 }

--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -37,8 +37,8 @@ class ResetCommand extends BaseCommand
         if (!$this->confirmToProceed()) {
             return 1;
         }
-        
-        $dependencyFactory = $provider->fromConnectionName(
+
+        $dependencyFactory = $provider->fromEntityManagerName(
             $this->option('connection')
         );
         $this->connection = $dependencyFactory->getConnection();

--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -49,24 +49,24 @@ class ResetCommand extends BaseCommand
         return 0;
     }
 
-    private function safelyDropTables()
+    private function safelyDropTables(): void
     {
         $this->throwExceptionIfPlatformIsNotSupported();
 
-        $schema = $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
-        if ($schema->getDatabasePlatform()->supportsSequences()) {
-            $sequences = $schema->listSequences();
+        if ($this->connection->getDatabasePlatform()->supportsSequences()) {
+            $sequences = $schemaManager->listSequences();
             foreach ($sequences as $s) {
-                $schema->dropSequence($s);
+                $schemaManager->dropSequence($s->getQuotedName($this->connection->getDatabasePlatform()));
             }
         }
 
-        $tables = $schema->listTableNames();
+        $tables = $schemaManager->listTableNames();
         foreach ($tables as $table) {
-            $foreigns = $schema->listTableForeignKeys($table);
+            $foreigns = $schemaManager->listTableForeignKeys($table);
             foreach ($foreigns as $f) {
-                $schema->dropForeignKey($f, $table);
+                $schemaManager->dropForeignKey($f, $table);
             }
         }
 
@@ -78,7 +78,7 @@ class ResetCommand extends BaseCommand
     /**
      * @throws Exception
      */
-    private function throwExceptionIfPlatformIsNotSupported()
+    private function throwExceptionIfPlatformIsNotSupported(): void
     {
         $platformName = $this->connection->getDatabasePlatform()->getName();
 
@@ -91,7 +91,7 @@ class ResetCommand extends BaseCommand
      * @param string $table
      * @throws \Doctrine\DBAL\Exception
      */
-    private function safelyDropTable(string $table)
+    private function safelyDropTable(string $table): void
     {
         $platformName = $this->connection->getDatabasePlatform()->getName();
         $instructions = $this->getCardinalityCheckInstructions()[$platformName];
@@ -112,7 +112,7 @@ class ResetCommand extends BaseCommand
     }
 
     /**
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     private function getCardinalityCheckInstructions(): array
     {

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -13,7 +13,7 @@ class RollbackCommand extends Command
      * @var string
      */
     protected $signature = 'doctrine:migrations:rollback {version?}
-    {--connection= : For a specific connection.}';
+    {--em= : For a specific EntityManager. }';
 
     /**
      * @var string
@@ -29,7 +29,7 @@ class RollbackCommand extends Command
     {
         return $this->call('doctrine:migrations:migrate', [
             'version' => 'prev',
-            '--connection' => $this->option('connection')
+            '--em' => $this->option('em')
         ]);
     }
 }

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -13,7 +13,7 @@ class StatusCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'doctrine:migrations:status
-    {--connection= : For a specific connection.}';
+    {--em= : For a specific EntityManager. }';
 
     /**
      * @var string
@@ -27,7 +27,7 @@ class StatusCommand extends BaseCommand
      */
     public function handle(DependencyFactoryProvider $provider): int
     {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\StatusCommand($dependencyFactory);
 

--- a/src/Console/SyncMetadataCommand.php
+++ b/src/Console/SyncMetadataCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LaravelDoctrine\Migrations\Console;
+
+use Illuminate\Console\Command;
+use LaravelDoctrine\Migrations\Configuration\DependencyFactoryProvider;
+
+class SyncMetadataCommand extends BaseCommand
+{
+    /**
+     * The name and signature of the console command.
+     * @var string
+     */
+    protected $signature = 'doctrine:migrations:sync-metadata-storage
+    {--em= : For a specific EntityManager. }';
+
+    /**
+     * @var string
+     */
+    protected $description = 'View the status of a set of migrations.';
+
+    /**
+     * Execute the console command.
+     *
+     * @param DependencyFactoryProvider $provider
+     */
+    public function handle(DependencyFactoryProvider $provider): int
+    {
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
+
+        $command = new \Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand($dependencyFactory);
+
+        return $command->run($this->getDoctrineInput($command), $this->output->getOutput());
+    }
+
+}

--- a/src/Console/VersionCommand.php
+++ b/src/Console/VersionCommand.php
@@ -13,7 +13,7 @@ class VersionCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'doctrine:migrations:version {version?}
-    {--connection= : For a specific connection.}
+    {--em= : For a specific EntityManager. }
     {--add : Add the specified version }
     {--delete : Delete the specified version.}
     {--all : Apply to all the versions.}
@@ -32,7 +32,7 @@ class VersionCommand extends BaseCommand
      */
     public function handle(DependencyFactoryProvider $provider): int
     {
-        $dependencyFactory = $provider->fromConnectionName($this->option('connection'));
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\VersionCommand($dependencyFactory);
         return $command->run($this->getDoctrineInput($command), $this->output->getOutput());

--- a/src/MigrationsServiceProvider.php
+++ b/src/MigrationsServiceProvider.php
@@ -65,7 +65,7 @@ class MigrationsServiceProvider extends ServiceProvider
     /**
      * Merge config
      */
-    protected function mergeConfig()
+    protected function mergeConfig(): void
     {
         if ($this->isLumen()) {
             $this->app->configure('migrations');
@@ -79,15 +79,15 @@ class MigrationsServiceProvider extends ServiceProvider
     /**
      * @return string
      */
-    protected function getConfigPath()
+    protected function getConfigPath(): string
     {
         return __DIR__ . '/../config/migrations.php';
     }
 
     /**
-     * @return array
+     * @return class-string[]
      */
-    public function provides()
+    public function provides(): array
     {
         return [
             DependencyFactoryProvider::class
@@ -97,7 +97,7 @@ class MigrationsServiceProvider extends ServiceProvider
     /**
      * @return bool
      */
-    protected function isLumen()
+    protected function isLumen(): bool
     {
         return Str::contains($this->app->version(), 'Lumen');
     }

--- a/src/MigrationsServiceProvider.php
+++ b/src/MigrationsServiceProvider.php
@@ -16,6 +16,7 @@ use LaravelDoctrine\Migrations\Console\RefreshCommand;
 use LaravelDoctrine\Migrations\Console\ResetCommand;
 use LaravelDoctrine\Migrations\Console\RollbackCommand;
 use LaravelDoctrine\Migrations\Console\StatusCommand;
+use LaravelDoctrine\Migrations\Console\SyncMetadataCommand;
 use LaravelDoctrine\Migrations\Console\VersionCommand;
 
 class MigrationsServiceProvider extends ServiceProvider
@@ -56,7 +57,8 @@ class MigrationsServiceProvider extends ServiceProvider
             VersionCommand::class,
             RefreshCommand::class,
             RollbackCommand::class,
-            GenerateCommand::class
+            GenerateCommand::class,
+            SyncMetadataCommand::class
         ]);
     }
 

--- a/tests/CommandConfigurationTest.php
+++ b/tests/CommandConfigurationTest.php
@@ -10,6 +10,7 @@ use LaravelDoctrine\Migrations\Console\GenerateCommand;
 use LaravelDoctrine\Migrations\Console\LatestCommand;
 use LaravelDoctrine\Migrations\Console\MigrateCommand;
 use LaravelDoctrine\Migrations\Console\StatusCommand;
+use LaravelDoctrine\Migrations\Console\SyncMetadataCommand;
 use LaravelDoctrine\Migrations\Console\VersionCommand;
 use function array_keys;
 use function implode;
@@ -28,7 +29,8 @@ class CommandConfigurationTest extends \PHPUnit\Framework\TestCase
             StatusCommand::class => \Doctrine\Migrations\Tools\Console\Command\StatusCommand::class,
             MigrateCommand::class => \Doctrine\Migrations\Tools\Console\Command\MigrateCommand::class,
             VersionCommand::class => \Doctrine\Migrations\Tools\Console\Command\VersionCommand::class,
-            GenerateCommand::class => \Doctrine\Migrations\Tools\Console\Command\GenerateCommand::class
+            GenerateCommand::class => \Doctrine\Migrations\Tools\Console\Command\GenerateCommand::class,
+            SyncMetadataCommand::class => \Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand::class,
         ];
 
         foreach ($commands as $ourCommandClass => $doctrineCommandClass) {

--- a/tests/CommandConfigurationTest.php
+++ b/tests/CommandConfigurationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace LaravelDoctrine\Migrations\Tests;
+
+use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Illuminate\Console\Command;
+use LaravelDoctrine\Migrations\Console\DiffCommand;
+use LaravelDoctrine\Migrations\Console\ExecuteCommand;
+use LaravelDoctrine\Migrations\Console\GenerateCommand;
+use LaravelDoctrine\Migrations\Console\LatestCommand;
+use LaravelDoctrine\Migrations\Console\MigrateCommand;
+use LaravelDoctrine\Migrations\Console\StatusCommand;
+use LaravelDoctrine\Migrations\Console\VersionCommand;
+use function array_keys;
+use function implode;
+use function in_array;
+use function PHPUnit\Framework\assertSame;
+
+class CommandConfigurationTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function testAllCommandsAreConfiguredCorrectly(): void
+    {
+        $commands = [
+            DiffCommand::class => \Doctrine\Migrations\Tools\Console\Command\DiffCommand::class,
+            ExecuteCommand::class => \Doctrine\Migrations\Tools\Console\Command\ExecuteCommand::class,
+            LatestCommand::class => \Doctrine\Migrations\Tools\Console\Command\LatestCommand::class,
+            StatusCommand::class => \Doctrine\Migrations\Tools\Console\Command\StatusCommand::class,
+            MigrateCommand::class => \Doctrine\Migrations\Tools\Console\Command\MigrateCommand::class,
+            VersionCommand::class => \Doctrine\Migrations\Tools\Console\Command\VersionCommand::class,
+            GenerateCommand::class => \Doctrine\Migrations\Tools\Console\Command\GenerateCommand::class
+        ];
+
+        foreach ($commands as $ourCommandClass => $doctrineCommandClass) {
+            /** @var Command $ourCommand */
+            $ourCommand = new $ourCommandClass();
+            /** @var DoctrineCommand $theirCommand */
+            $theirCommand = new $doctrineCommandClass();
+
+            self::assertDefinedSameOptions($ourCommand, $theirCommand);
+            self::assertSameCommandConfiguration($ourCommand, $theirCommand);
+        }
+    }
+
+    private static function assertSameCommandConfiguration(Command $ourCommand, DoctrineCommand $theirCommand): void
+    {
+        // We set a default value for these options
+        $optionsIgnoredForRequired = ['em', 'filter-expression'];
+
+        // Assert option configuration
+        foreach ($ourCommand->getDefinition()->getOptions() as $ourOption) {
+            foreach ($theirCommand->getDefinition()->getOptions() as $theirOption) {
+                if ($ourOption->getName() === $theirOption->getName()) {
+                    // Assert property is required in our and their configuration
+                    if (in_array($ourOption->getName(), $optionsIgnoredForRequired) === false) {
+                        // Ignore those were we have specified value
+                        if (empty($ourOption->getDefault())) {
+                            self::assertSame($ourOption->isValueRequired(), $theirOption->isValueRequired(), "Mismatch 'required' state on option value for {$ourCommand->getName()} {$ourOption->getName()}. Their '{$theirOption->isValueRequired()}', our: '{$ourOption->isValueRequired()}'");
+                        }
+
+                        self::assertSame($ourOption->acceptValue(), $theirOption->acceptValue(), "Mismatch 'acceptValue' state on option value for {$ourCommand->getName()} {$ourOption->getName()}. Their '{$theirOption->acceptValue()}', our: '{$ourOption->acceptValue()}'");
+                    }
+
+
+                    // Assert default values matches
+                    if ($theirOption->getDefault() !== false) {
+                        self::assertEquals($ourOption->getDefault(), $theirOption->getDefault(), "Mismatch default value for {$ourCommand->getName()} {$ourOption->getName()}. Their: '{$theirOption->getDefault()}', our: '{$ourOption->getDefault()}'");
+                    }
+                }
+            }
+        }
+
+        // Assert argument configuration
+        foreach ($ourCommand->getDefinition()->getArguments() as $ourArgument) {
+            foreach ($theirCommand->getDefinition()->getArguments() as $theirArgument) {
+                if ($ourArgument->getName() === $theirArgument->getName()) {
+                    $theirDefaultValue = print_r($theirArgument->getDefault(), true);
+                    $ourDefaultValue = print_r($ourArgument->getDefault(), true);
+
+                    if (empty($ourArgument->getDefault()) && empty($theirArgument->getDefault())) {
+                        continue;
+                    }
+
+                    self::assertEquals($ourArgument->getDefault(), $theirArgument->getDefault(), "Mismatch default value for {$ourCommand->getName()} {$ourArgument->getName()}. Their: '{$theirDefaultValue}', our: '{$ourDefaultValue}'");
+                }
+            }
+        }
+    }
+
+    private static function assertDefinedSameOptions(Command $ourCommand, DoctrineCommand $theirCommand): void
+    {
+        // Options we do not support. They are defined on DoctrineCommand and applies for all their commands.
+        $globalIgnoredOptions = [
+            'configuration', 'conn', 'db-configuration', 'namespace'
+        ];
+
+        $commandName = $ourCommand->getName();
+
+        $ourOptionNames = array_keys($ourCommand->getDefinition()->getOptions());
+        $theirOptionNames = array_keys($theirCommand->getDefinition()->getOptions());
+
+        $ourExtraOptions = [];
+        $doctrineExtraOptions = [];
+
+        foreach ($ourOptionNames as $ourOption) {
+            if ($ourOption === 'connection') {
+                // Our custom connection option
+                continue;
+            }
+
+            if (in_array($ourOption, $theirOptionNames, true) === false) {
+                $ourExtraOptions[] = $ourOption;
+            }
+        }
+
+
+        foreach ($theirOptionNames as $theirOption) {
+            if (in_array($theirOption, $globalIgnoredOptions, true)) {
+                continue;
+            }
+
+            if (in_array($theirOption, $ourOptionNames, true) === false) {
+                $doctrineExtraOptions[] = $theirOption;
+            }
+        }
+
+        self::assertEmpty($ourExtraOptions, 'Command '.$commandName.' has options not supported by doctrine command: ' . implode(", ", $ourExtraOptions));
+        self::assertEmpty($doctrineExtraOptions, 'Command '.$commandName.' is missing options from doctrine command: ' . implode(", ", $doctrineExtraOptions));
+
+    }
+}


### PR DESCRIPTION
- Revert change of version_column_length from 14 to 1024 (introduced in 3.x). Instead go to 191 as this is the actual default in doctrine/migrations.
- Rename `--conn` to `--em` because it is actually looking up the entity manager name. Also it match better with `--em` which we use in laravel-doctrine/orm.
- Add missing options on diff and migrate commands.
- Testcase to make sure we always match the signature from doctrine
  - Run tests every night to make sure we are up-to-date with doctrine/migrations
- Remove /tmp as default value for --write-sql
- Add `doctrine:migrations:sync-metadata-storage`
