### PR TITLE
Add back schema builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   "require": {
     "php": "^7.4|^8",
     "doctrine/migrations": "^3.4",
+    "doctrine/dbal": "^2.10.1|^3",
     "illuminate/config": "^6.0|^7.0|^8.0|^9.0",
     "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
     "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
@@ -27,7 +28,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0 | ^8.3 | ^9.3",
-    "phpstan/phpstan": "^1.9"
+    "phpstan/phpstan": "^1.9",
+    "mockery/mockery": "^1.3.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelDoctrine\Migrations\Schema;
+
+use Closure;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+
+class Builder
+{
+    /**
+     * @var Schema
+     */
+    protected $schema;
+
+    /**
+     * @param Schema $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Modify a table on the schema.
+     *
+     * @param string $table
+     * @param Closure $callback
+     *
+     * @return \Doctrine\DBAL\Schema\Table|string
+     */
+    public function create(string $table, Closure $callback)
+    {
+        $table = $this->schema->createTable($table);
+
+        $callback($this->build($table));
+
+        return $table;
+    }
+
+    /**
+     * Create a new table on the schema.
+     *
+     * @param string $table
+     * @param Closure $callback
+     *
+     * @return \Doctrine\DBAL\Schema\Table|string
+     * @throws SchemaException
+     */
+    public function table(string $table, Closure $callback)
+    {
+        $table = $this->schema->getTable($table);
+
+        $callback($this->build($table));
+
+        return $table;
+    }
+
+    /**
+     * Drop a table from the schema.
+     *
+     * @param string $table
+     *
+     * @return Schema|string
+     */
+    public function drop(string $table)
+    {
+        return $this->schema->dropTable($table);
+    }
+
+    /**
+     * Drop a table from the schema if it exists.
+     *
+     * @param string $table
+     *
+     * @return Schema|string
+     */
+    public function dropIfExists(string $table)
+    {
+        if ($this->schema->hasTable($table)) {
+            return $this->drop($table);
+        }
+    }
+
+    /**
+     * Rename a table on the schema.
+     *
+     * @param string $from
+     * @param string $to
+     *
+     * @return Schema|string
+     */
+    public function rename(string $from, string $to)
+    {
+        return $this->schema->renameTable($from, $to);
+    }
+
+    /**
+     * Determine if the given table exists.
+     *
+     * @param string $table
+     *
+     * @return bool
+     */
+    public function hasTable(string $table): bool
+    {
+        return $this->schema->hasTable($table);
+    }
+
+    /**
+     * Determine if the given table has a given column.
+     *
+     * @param string $table
+     * @param string $column
+     *
+     * @return bool
+     * @throws SchemaException
+     */
+    public function hasColumn(string $table, string $column): bool
+    {
+        return $this->schema->getTable($table)->hasColumn($column);
+    }
+
+    /**
+     * Determine if the given table has given columns.
+     *
+     * @param string $table
+     * @param array $columns
+     *
+     * @return bool
+     * @throws SchemaException
+     */
+    public function hasColumns(string $table, array $columns): bool
+    {
+        $tableColumns = array_map('strtolower', array_keys($this->getColumnListing($table)));
+
+        foreach ($columns as $column) {
+            if (!in_array(strtolower($column), $tableColumns)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the column listing for a given table.
+     *
+     * @param string $table
+     *
+     * @return array
+     * @throws SchemaException
+     */
+    public function getColumnListing(string $table): array
+    {
+        return $this->schema->getTable($table)->getColumns();
+    }
+
+    /**
+     * @param              $table
+     * @param Closure|null $callback
+     *
+     * @return Table
+     */
+    protected function build($table, Closure $callback = null): Table
+    {
+        return new Table($table, $callback);
+    }
+}

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaravelDoctrine\Migrations\Schema;
 
 use Closure;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 
@@ -75,13 +76,15 @@ class Builder
      *
      * @param string $table
      *
-     * @return Schema|string
+     * @return Schema|string|null
      */
     public function dropIfExists(string $table)
     {
         if ($this->schema->hasTable($table)) {
             return $this->drop($table);
         }
+
+        return null;
     }
 
     /**
@@ -127,7 +130,7 @@ class Builder
      * Determine if the given table has given columns.
      *
      * @param string $table
-     * @param array $columns
+     * @param string[] $columns
      *
      * @return bool
      * @throws SchemaException
@@ -150,7 +153,7 @@ class Builder
      *
      * @param string $table
      *
-     * @return array
+     * @return Column[]
      * @throws SchemaException
      */
     public function getColumnListing(string $table): array
@@ -159,7 +162,7 @@ class Builder
     }
 
     /**
-     * @param              $table
+     * @param \Doctrine\DBAL\Schema\Table $table
      * @param Closure|null $callback
      *
      * @return Table

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -8,6 +8,7 @@ use Closure;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table as Blueprint;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 class Table
 {
@@ -38,7 +39,7 @@ class Table
      */
     public function guid(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::GUID);
+        return $this->table->addColumn($column, Types::GUID);
     }
 
     /**
@@ -170,7 +171,7 @@ class Table
      */
     public function string(string $column, $length = 255): ?Column
     {
-        return $this->table->addColumn($column, Type::STRING, compact('length'));
+        return $this->table->addColumn($column, Types::STRING, compact('length'));
     }
 
     /**
@@ -182,7 +183,7 @@ class Table
      */
     public function text(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::TEXT);
+        return $this->table->addColumn($column, Types::TEXT);
     }
 
     /**
@@ -196,7 +197,7 @@ class Table
      */
     public function integer(string $column, $autoIncrement = false, $unsigned = false): ?Column
     {
-        return $this->table->addColumn($column, Type::INTEGER, compact('autoIncrement', 'unsigned'));
+        return $this->table->addColumn($column, Types::INTEGER, compact('autoIncrement', 'unsigned'));
     }
 
     /**
@@ -210,7 +211,7 @@ class Table
      */
     public function smallInteger(string $column, $autoIncrement = false, $unsigned = false): ?Column
     {
-        return $this->table->addColumn($column, Type::SMALLINT, compact('autoIncrement', 'unsigned'));
+        return $this->table->addColumn($column, Types::SMALLINT, compact('autoIncrement', 'unsigned'));
     }
 
     /**
@@ -224,7 +225,7 @@ class Table
      */
     public function bigInteger(string $column, $autoIncrement = false, $unsigned = false): ?Column
     {
-        return $this->table->addColumn($column, Type::BIGINT, compact('autoIncrement', 'unsigned'));
+        return $this->table->addColumn($column, Types::BIGINT, compact('autoIncrement', 'unsigned'));
     }
 
     /**
@@ -277,7 +278,7 @@ class Table
      */
     public function float(string $column, $precision = 8, $scale = 2): ?Column
     {
-        return $this->table->addColumn($column, Type::FLOAT, compact('precision', 'scale'));
+        return $this->table->addColumn($column, Types::FLOAT, compact('precision', 'scale'));
     }
 
     /**
@@ -291,7 +292,7 @@ class Table
      */
     public function decimal(string $column, $precision = 8, $scale = 2): ?Column
     {
-        return $this->table->addColumn($column, Type::DECIMAL, compact('precision', 'scale'));
+        return $this->table->addColumn($column, Types::DECIMAL, compact('precision', 'scale'));
     }
 
     /**
@@ -303,7 +304,7 @@ class Table
      */
     public function boolean(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::BOOLEAN);
+        return $this->table->addColumn($column, Types::BOOLEAN);
     }
 
     /**
@@ -315,7 +316,7 @@ class Table
      */
     public function json(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::JSON_ARRAY);
+        return $this->table->addColumn($column, Types::JSON);
     }
 
     /**
@@ -327,7 +328,7 @@ class Table
      */
     public function date(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::DATE);
+        return $this->table->addColumn($column, Types::DATE_MUTABLE);
     }
 
     /**
@@ -339,7 +340,7 @@ class Table
      */
     public function dateTime(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::DATETIME);
+        return $this->table->addColumn($column, Types::DATETIME_MUTABLE);
     }
 
     /**
@@ -351,7 +352,7 @@ class Table
      */
     public function dateTimeTz(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::DATETIMETZ);
+        return $this->table->addColumn($column, Types::DATETIMETZ_MUTABLE);
     }
 
     /**
@@ -363,7 +364,7 @@ class Table
      */
     public function time(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::TIME);
+        return $this->table->addColumn($column, Types::TIME_MUTABLE);
     }
 
     /**
@@ -375,7 +376,7 @@ class Table
      */
     public function timestamp(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::DATETIME);
+        return $this->table->addColumn($column, Types::DATETIME_MUTABLE);
     }
 
     /**
@@ -387,7 +388,7 @@ class Table
      */
     public function timestampTz(string $column): ?Column
     {
-        return $this->table->addColumn($column, Type::DATETIMETZ);
+        return $this->table->addColumn($column, Types::DATETIMETZ_MUTABLE);
     }
 
     /**
@@ -442,7 +443,7 @@ class Table
      */
     public function binary(string $column, $length = 255): ?Column
     {
-        return $this->table->addColumn($column, Type::BINARY, compact('length'))->setNotnull(false);
+        return $this->table->addColumn($column, Types::BINARY, compact('length'))->setNotnull(false);
     }
 
     /**

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -1,0 +1,475 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelDoctrine\Migrations\Schema;
+
+use Closure;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table as Blueprint;
+use Doctrine\DBAL\Types\Type;
+
+class Table
+{
+    /**
+     * @var Blueprint
+     */
+    protected $table;
+
+    /**
+     * @param Blueprint $table
+     * @param Closure|null $callback
+     */
+    public function __construct(Blueprint $table, Closure $callback = null)
+    {
+        $this->table = $table;
+
+        if (!is_null($callback)) {
+            $callback($this);
+        }
+    }
+
+    /**
+     * Create a new guid column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function guid(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::GUID);
+    }
+
+    /**
+     * Specify the primary key(s) for the table.
+     *
+     * @param string $columns
+     * @param null $name
+     *
+     * @return Blueprint|null
+     */
+    public function primary(string $columns, $name = null): ?Blueprint
+    {
+        $columns = is_array($columns) ? $columns : [$columns];
+
+        return $this->table->setPrimaryKey($columns, $name);
+    }
+
+    /**
+     * Specify a unique index for the table.
+     *
+     * @param string|array $columns
+     * @param string       $name
+     * @param array        $options
+     *
+     * @return Blueprint|null
+     */
+    public function unique($columns, $name = null, $options = []): ?Blueprint
+    {
+        $columns = is_array($columns) ? $columns : [$columns];
+
+        return $this->table->addUniqueIndex($columns, $name, $options);
+    }
+
+    /**
+     * Specify an index for the table.
+     *
+     * @param string|array $columns
+     * @param string       $name
+     * @param array        $flags
+     * @param array        $options
+     *
+     * @return Blueprint|null
+     */
+    public function index($columns, $name = null, $flags = [], $options = []): ?Blueprint
+    {
+        $columns = is_array($columns) ? $columns : [$columns];
+
+        return $this->table->addIndex($columns, $name, $flags, $options);
+    }
+
+    /**
+     * Specify a foreign key for the table.
+     *
+     * @param string $table
+     * @param array|string $localColumnNames
+     * @param array|string $foreignColumnNames
+     * @param array $options
+     * @param null $constraintName
+     *
+     * @return Blueprint|null
+     */
+    public function foreign(
+        string $table,
+        $localColumnNames,
+        $foreignColumnNames = 'id',
+        $options = [],
+        $constraintName = null
+    ): ?Blueprint
+    {
+        $localColumnNames   = is_array($localColumnNames) ? $localColumnNames : [$localColumnNames];
+        $foreignColumnNames = is_array($foreignColumnNames) ? $foreignColumnNames : [$foreignColumnNames];
+
+        return $this->table->addForeignKeyConstraint($table, $localColumnNames, $foreignColumnNames, $options,
+            $constraintName);
+    }
+
+    /**
+     * Create a new auto-incrementing integer (4-byte) column on the table.
+     *
+     * @param string $columnName
+     *
+     * @return Column|null
+     */
+    public function increments(string $columnName): ?Column
+    {
+        $column = $this->integer($columnName, true, true);
+        $this->primary($columnName);
+
+        return $column;
+    }
+
+    /**
+     * Create a new auto-incrementing small integer (2-byte) column on the table.
+     *
+     * @param string $columnName
+     *
+     * @return Column|null
+     */
+    public function smallIncrements(string $columnName): ?Column
+    {
+        $column = $this->smallInteger($columnName, true, true);
+        $this->primary($columnName);
+
+        return $column;
+    }
+
+    /**
+     * Create a new auto-incrementing big integer (8-byte) column on the table.
+     *
+     * @param string $columnName
+     *
+     * @return Column|null
+     */
+    public function bigIncrements(string $columnName): ?Column
+    {
+        $column = $this->bigInteger($columnName, true, true);
+        $this->primary($columnName);
+
+        return $column;
+    }
+
+    /**
+     * Create a new string column on the table.
+     *
+     * @param string $column
+     * @param int $length
+     *
+     * @return Column|null
+     */
+    public function string(string $column, $length = 255): ?Column
+    {
+        return $this->table->addColumn($column, Type::STRING, compact('length'));
+    }
+
+    /**
+     * Create a new text column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function text(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::TEXT);
+    }
+
+    /**
+     * Create a new integer (4-byte) column on the table.
+     *
+     * @param string $column
+     * @param bool $autoIncrement
+     * @param bool $unsigned
+     *
+     * @return Column|null
+     */
+    public function integer(string $column, $autoIncrement = false, $unsigned = false): ?Column
+    {
+        return $this->table->addColumn($column, Type::INTEGER, compact('autoIncrement', 'unsigned'));
+    }
+
+    /**
+     * Create a new small integer (2-byte) column on the table.
+     *
+     * @param string $column
+     * @param bool $autoIncrement
+     * @param bool $unsigned
+     *
+     * @return Column|null
+     */
+    public function smallInteger(string $column, $autoIncrement = false, $unsigned = false): ?Column
+    {
+        return $this->table->addColumn($column, Type::SMALLINT, compact('autoIncrement', 'unsigned'));
+    }
+
+    /**
+     * Create a new big integer (8-byte) column on the table.
+     *
+     * @param string $column
+     * @param bool $autoIncrement
+     * @param bool $unsigned
+     *
+     * @return Column|null
+     */
+    public function bigInteger(string $column, $autoIncrement = false, $unsigned = false): ?Column
+    {
+        return $this->table->addColumn($column, Type::BIGINT, compact('autoIncrement', 'unsigned'));
+    }
+
+    /**
+     * Create a new unsigned small integer (2-byte) column on the table.
+     *
+     * @param string $column
+     * @param bool $autoIncrement
+     *
+     * @return Column|null
+     */
+    public function unsignedSmallInteger(string $column, $autoIncrement = false): ?Column
+    {
+        return $this->smallInteger($column, $autoIncrement, true);
+    }
+
+    /**
+     * Create a new unsigned integer (4-byte) column on the table.
+     *
+     * @param string $column
+     * @param bool $autoIncrement
+     *
+     * @return Column|null
+     */
+    public function unsignedInteger(string $column, $autoIncrement = false): ?Column
+    {
+        return $this->integer($column, $autoIncrement, true);
+    }
+
+    /**
+     * Create a new unsigned big integer (8-byte) column on the table.
+     *
+     * @param string $column
+     * @param bool $autoIncrement
+     *
+     * @return Column|null
+     */
+    public function unsignedBigInteger(string $column, $autoIncrement = false): ?Column
+    {
+        return $this->bigInteger($column, $autoIncrement, true);
+    }
+
+    /**
+     * Create a new float column on the table.
+     *
+     * @param string $column
+     * @param int $precision
+     * @param int $scale
+     *
+     * @return Column|null
+     */
+    public function float(string $column, $precision = 8, $scale = 2): ?Column
+    {
+        return $this->table->addColumn($column, Type::FLOAT, compact('precision', 'scale'));
+    }
+
+    /**
+     * Create a new decimal column on the table.
+     *
+     * @param string $column
+     * @param int $precision
+     * @param int $scale
+     *
+     * @return Column|null
+     */
+    public function decimal(string $column, $precision = 8, $scale = 2): ?Column
+    {
+        return $this->table->addColumn($column, Type::DECIMAL, compact('precision', 'scale'));
+    }
+
+    /**
+     * Create a new boolean column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function boolean(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::BOOLEAN);
+    }
+
+    /**
+     * Create a new json column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function json(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::JSON_ARRAY);
+    }
+
+    /**
+     * Create a new date column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function date(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::DATE);
+    }
+
+    /**
+     * Create a new date-time column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function dateTime(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::DATETIME);
+    }
+
+    /**
+     * Create a new date-time column (with time zone) on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function dateTimeTz(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::DATETIMETZ);
+    }
+
+    /**
+     * Create a new time column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function time(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::TIME);
+    }
+
+    /**
+     * Create a new timestamp column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function timestamp(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::DATETIME);
+    }
+
+    /**
+     * Create a new timestamp (with time zone) column on the table.
+     *
+     * @param string $column
+     *
+     * @return Column|null
+     */
+    public function timestampTz(string $column): ?Column
+    {
+        return $this->table->addColumn($column, Type::DATETIMETZ);
+    }
+
+    /**
+     * Add nullable creation and update timestamps to the table.
+     * @return void
+     */
+    public function nullableTimestamps()
+    {
+        $this->timestamp('created_at')->setNotnull(false);
+
+        $this->timestamp('updated_at')->setNotnull(false);
+    }
+
+    /**
+     * Add creation and update timestamps to the table.
+     * @return void
+     */
+    public function timestamps()
+    {
+        $this->timestamp('created_at');
+
+        $this->timestamp('updated_at');
+    }
+
+    /**
+     * Add creation and update timestampTz columns to the table.
+     * @return void
+     */
+    public function timestampsTz()
+    {
+        $this->timestampTz('created_at');
+
+        $this->timestampTz('updated_at');
+    }
+
+    /**
+     * Add a "deleted at" timestamp for the table.
+     *
+     * @return Column|null
+     */
+    public function softDeletes(): ?Column
+    {
+        return $this->timestamp('deleted_at')->setNotnull(false);
+    }
+
+    /**
+     * Create a new binary column on the table.
+     *
+     * @param string $column
+     * @param int $length
+     * @return Column|null
+     */
+    public function binary(string $column, $length = 255): ?Column
+    {
+        return $this->table->addColumn($column, Type::BINARY, compact('length'))->setNotnull(false);
+    }
+
+    /**
+     * Adds the `remember_token` column to the table.
+     *
+     * @return Column|null
+     */
+    public function rememberToken(): ?Column
+    {
+        return $this->string('remember_token', 100)->setNotnull(false);
+    }
+
+    /**
+     * @return Blueprint
+     */
+    public function getTable(): Blueprint
+    {
+        return $this->table;
+    }
+
+    /**
+     * @param $column
+     *
+     * @return Blueprint|null
+     */
+    public function dropColumn($column): ?Blueprint
+    {
+        return $this->table->dropColumn($column);
+    }
+}

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -45,24 +45,24 @@ class Table
     /**
      * Specify the primary key(s) for the table.
      *
-     * @param string $columns
-     * @param null $name
+     * @param string|string[] $columns
+     * @param string|false $indexName
      *
      * @return Blueprint|null
      */
-    public function primary(string $columns, $name = null): ?Blueprint
+    public function primary($columns, $indexName = false): ?Blueprint
     {
         $columns = is_array($columns) ? $columns : [$columns];
 
-        return $this->table->setPrimaryKey($columns, $name);
+        return $this->table->setPrimaryKey($columns, $indexName);
     }
 
     /**
      * Specify a unique index for the table.
      *
-     * @param string|array $columns
+     * @param string|string[] $columns
      * @param string       $name
-     * @param array        $options
+     * @param mixed[]      $options
      *
      * @return Blueprint|null
      */
@@ -76,10 +76,10 @@ class Table
     /**
      * Specify an index for the table.
      *
-     * @param string|array $columns
+     * @param string|string[] $columns
      * @param string       $name
-     * @param array        $flags
-     * @param array        $options
+     * @param string[]     $flags
+     * @param mixed[]      $options
      *
      * @return Blueprint|null
      */
@@ -94,9 +94,9 @@ class Table
      * Specify a foreign key for the table.
      *
      * @param string $table
-     * @param array|string $localColumnNames
-     * @param array|string $foreignColumnNames
-     * @param array $options
+     * @param string[]|string $localColumnNames
+     * @param string[]|string $foreignColumnNames
+     * @param mixed[] $options
      * @param null $constraintName
      *
      * @return Blueprint|null
@@ -465,11 +465,9 @@ class Table
     }
 
     /**
-     * @param $column
-     *
      * @return Blueprint|null
      */
-    public function dropColumn($column): ?Blueprint
+    public function dropColumn(string $column): ?Blueprint
     {
         return $this->table->dropColumn($column);
     }

--- a/tests/Schema/SchemaBuilderTest.php
+++ b/tests/Schema/SchemaBuilderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\Schema\Schema;
+use LaravelDoctrine\Migrations\Schema\Builder;
+use LaravelDoctrine\Migrations\Schema\Table;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class SchemaBuilderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var Mockery\Mock
+     */
+    protected $schema;
+
+    /**
+     * @var Builder
+     */
+    protected $builder;
+
+    protected function setUp(): void
+    {
+        $this->schema  = m::mock(Schema::class);
+        $this->builder = new Builder($this->schema);
+    }
+
+    public function test_create()
+    {
+        $this->schema->shouldReceive('createTable')
+                     ->with('table_name')->once()
+                     ->andReturn(m::mock(\Doctrine\DBAL\Schema\Table::class));
+
+        $this->builder->create('table_name', function (Table $table) {
+            $this->assertInstanceOf(Table::class, $table);
+        });
+    }
+
+    public function test_table()
+    {
+        $this->schema->shouldReceive('getTable')
+                     ->with('table_name')->once()
+                     ->andReturn(m::mock(\Doctrine\DBAL\Schema\Table::class));
+
+        $this->builder->table('table_name', function (Table $table) {
+            $this->assertInstanceOf(Table::class, $table);
+        });
+    }
+
+    public function test_drop()
+    {
+        $this->schema->shouldReceive('dropTable')
+                     ->with('table_name')->once()
+                     ->andReturn('dropped');
+
+        $this->assertEquals('dropped', $this->builder->drop('table_name'));
+    }
+
+    public function test_dropIfExists()
+    {
+        $this->schema->shouldReceive('hasTable')
+                     ->with('table_name')->once()
+                     ->andReturn(true);
+
+        $this->schema->shouldReceive('dropTable')
+                     ->with('table_name')->once()
+                     ->andReturn('dropped');
+
+        $this->assertEquals('dropped', $this->builder->dropIfExists('table_name'));
+    }
+
+    public function test_rename()
+    {
+        $this->schema->shouldReceive('renameTable')
+                     ->with('table_name', 'tablename')->once()
+                     ->andReturn('renamed');
+
+        $this->assertEquals('renamed', $this->builder->rename('table_name', 'tablename'));
+    }
+
+    public function test_hasTable()
+    {
+        $this->schema->shouldReceive('hasTable')
+                     ->with('table_name')->once()
+                     ->andReturn(true);
+
+        $this->assertTrue($this->builder->hasTable('table_name'));
+    }
+
+    public function test_hasColumn()
+    {
+        $table = m::mock(\Doctrine\DBAL\Schema\Table::class);
+
+        $this->schema->shouldReceive('getTable')
+                     ->with('table_name')->once()
+                     ->andReturn($table);
+
+        $table->shouldReceive('hasColumn')->once()->with('column_name')->andReturn(true);
+
+        $this->assertTrue($this->builder->hasColumn('table_name', 'column_name'));
+    }
+
+    public function test_getColumnListing()
+    {
+        $table = m::mock(\Doctrine\DBAL\Schema\Table::class);
+
+        $this->schema->shouldReceive('getTable')
+                     ->with('table_name')->once()
+                     ->andReturn($table);
+
+        $table->shouldReceive('getColumns')->once()->andReturn(['column']);
+
+        $this->assertContains('column', $this->builder->getColumnListing('table_name'));
+    }
+
+    public function test_has_columns()
+    {
+        $table = m::mock(\Doctrine\DBAL\Schema\Table::class);
+
+        $this->schema->shouldReceive('getTable')
+                     ->with('table_name')->once()
+                     ->andReturn($table);
+
+        $table->shouldReceive('getColumns')->once()->andReturn(['column' => 'instance']);
+
+        $this->assertTrue($this->builder->hasColumns('table_name', ['column']));
+    }
+
+    public function test_doesnt_have_column()
+    {
+        $table = m::mock(\Doctrine\DBAL\Schema\Table::class);
+
+        $this->schema->shouldReceive('getTable')
+                     ->with('table_name')->once()
+                     ->andReturn($table);
+
+        $table->shouldReceive('getColumns')->once()->andReturn(['column' => 'instance']);
+
+        $this->assertFalse($this->builder->hasColumns('table_name', ['column2']));
+    }
+}

--- a/tests/Schema/SchemaTableTest.php
+++ b/tests/Schema/SchemaTableTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\Schema\Column;
+use LaravelDoctrine\Migrations\Schema\Table;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class SchemaTableTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var Mockery\Mock
+     */
+    protected $dbal;
+
+    /**
+     * @var Table
+     */
+    protected $table;
+
+    protected function setUp(): void
+    {
+        $this->dbal  = m::mock(\Doctrine\DBAL\Schema\Table::class);
+        $this->table = new Table($this->dbal);
+    }
+
+    public function test_guid()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('guid', 'guid');
+
+        $this->table->guid('guid');
+    }
+
+    public function test_primary()
+    {
+        $this->dbal->shouldReceive('setPrimaryKey')->with(['id'], null);
+
+        $this->table->primary('id');
+    }
+
+    public function test_unique()
+    {
+        $this->dbal->shouldReceive('addUniqueIndex')->with(['email'], null, []);
+
+        $this->table->unique('email');
+    }
+
+    public function test_index()
+    {
+        $this->dbal->shouldReceive('addIndex')->with(['email'], null, [], []);
+
+        $this->table->index('email');
+    }
+
+    public function test_foreign()
+    {
+        $this->dbal->shouldReceive('addForeignKeyConstraint')->with('users', ['user_id'], ['id'], [], null);
+
+        $this->table->foreign('users', 'user_id', 'id');
+    }
+
+    public function test_increments()
+    {
+        $this->dbal->shouldReceive('addColumn')->with(
+            'id',
+            'integer',
+            [
+                'autoIncrement' => true,
+                'unsigned'      => true
+            ]
+        );
+        $this->dbal->shouldReceive('setPrimaryKey')->with(['id'], null);
+
+        $this->table->increments('id');
+    }
+
+    public function test_small_increments()
+    {
+        $this->dbal->shouldReceive('addColumn')->with(
+            'id',
+            'smallint',
+            [
+                'autoIncrement' => true,
+                'unsigned'      => true
+            ]
+        );
+        $this->dbal->shouldReceive('setPrimaryKey')->with(['id'], null);
+
+        $this->table->smallIncrements('id');
+    }
+
+    public function test_big_increments()
+    {
+        $this->dbal->shouldReceive('addColumn')->with(
+            'id',
+            'bigint',
+            [
+                'autoIncrement' => true,
+                'unsigned'      => true
+            ]
+        );
+        $this->dbal->shouldReceive('setPrimaryKey')->with(['id'], null);
+
+        $this->table->bigIncrements('id');
+    }
+
+    public function test_string()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('string', 'string', ['length' => 255]);
+        $this->table->string('string');
+    }
+
+    public function test_text()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('text', 'text');
+        $this->table->text('text');
+    }
+
+    public function test_integer()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'integer', [
+            'autoIncrement' => false,
+            'unsigned'      => false
+        ]);
+        $this->table->integer('column');
+
+        $this->dbal->shouldReceive('addColumn')->with('column', 'integer', [
+            'autoIncrement' => true,
+            'unsigned'      => true
+        ]);
+        $this->table->integer('column', true, true);
+    }
+
+    public function test_small_integer()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'smallint', [
+            'autoIncrement' => false,
+            'unsigned'      => false
+        ]);
+        $this->table->smallInteger('column');
+
+        $this->dbal->shouldReceive('addColumn')->with('column', 'smallint', [
+            'autoIncrement' => true,
+            'unsigned'      => true
+        ]);
+        $this->table->smallInteger('column', true, true);
+    }
+
+    public function test_big_integer()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'bigint', [
+            'autoIncrement' => false,
+            'unsigned'      => false
+        ]);
+        $this->table->bigInteger('column');
+
+        $this->dbal->shouldReceive('addColumn')->with('column', 'bigint', [
+            'autoIncrement' => true,
+            'unsigned'      => true
+        ]);
+        $this->table->bigInteger('column', true, true);
+    }
+
+    public function test_unsigned_smallint()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'smallint', [
+            'autoIncrement' => false,
+            'unsigned'      => true
+        ]);
+        $this->table->unsignedSmallInteger('column');
+    }
+
+    public function test_unsigned_integer()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'integer', [
+            'autoIncrement' => false,
+            'unsigned'      => true
+        ]);
+        $this->table->unsignedInteger('column');
+    }
+
+    public function test_unsigned_bigint()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'bigint', [
+            'autoIncrement' => false,
+            'unsigned'      => true
+        ]);
+        $this->table->unsignedBigInteger('column');
+    }
+
+    public function test_float()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'float', [
+            'precision' => 8,
+            'scale'     => 2
+        ]);
+        $this->table->float('column');
+    }
+
+    public function test_decimal()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'decimal', [
+            'precision' => 8,
+            'scale'     => 2
+        ]);
+        $this->table->decimal('column');
+    }
+
+    public function test_boolean()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'boolean');
+        $this->table->boolean('column');
+    }
+
+    public function test_json()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'json_array');
+        $this->table->json('column');
+    }
+
+    public function test_date()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'date');
+        $this->table->date('column');
+    }
+
+    public function test_dateTime()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'datetime');
+        $this->table->dateTime('column');
+    }
+
+    public function test_dateTimeTz()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'datetimetz');
+        $this->table->dateTimeTz('column');
+    }
+
+    public function test_timestamp()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'datetime');
+        $this->table->timestamp('column');
+    }
+
+    public function test_timestampTz()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('column', 'datetimetz');
+        $this->table->timestampTz('column');
+    }
+
+    public function test_nullable_timestamps()
+    {
+        $column = m::mock(Column::class);
+        $this->dbal->shouldReceive('addColumn')->with('created_at', 'datetime')->andReturn($column);
+        $this->dbal->shouldReceive('addColumn')->with('updated_at', 'datetime')->andReturn($column);
+        $column->shouldReceive('setNotnull')->with(false)->twice();
+        $this->table->nullableTimestamps();
+    }
+
+    public function test_timestamps()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('created_at', 'datetime');
+        $this->dbal->shouldReceive('addColumn')->with('updated_at', 'datetime');
+        $this->table->timestamps();
+    }
+
+    public function test_timestampsTz()
+    {
+        $this->dbal->shouldReceive('addColumn')->with('created_at', 'datetimetz');
+        $this->dbal->shouldReceive('addColumn')->with('updated_at', 'datetimetz');
+        $this->table->timestampsTz();
+    }
+
+    public function test_softdeletes()
+    {
+        $column = m::mock(Column::class);
+        $this->dbal->shouldReceive('addColumn')->with('deleted_at', 'datetime')->andReturn($column);
+        $column->shouldReceive('setNotnull')->with(false)->once();
+        $this->table->softDeletes();
+    }
+
+    public function test_binary()
+    {
+        $column = m::mock(Column::class);
+        $this->dbal->shouldReceive('addColumn')->with('column', 'binary', ['length' => 255])->andReturn($column);
+        $column->shouldReceive('setNotnull')->with(false)->once();
+        $this->table->binary('column');
+    }
+
+    public function test_remember_token()
+    {
+        $column = m::mock(Column::class);
+        $this->dbal->shouldReceive('addColumn')->with('remember_token', 'string', ['length' => 100])
+                   ->andReturn($column);
+        $column->shouldReceive('setNotnull')->with(false)->once();
+        $this->table->rememberToken('column');
+    }
+
+    public function test_get_dbal_table()
+    {
+        $this->assertInstanceOf(\Doctrine\DBAL\Schema\Table::class, $this->table->getTable());
+    }
+
+    public function test_drop_column()
+    {
+        $this->dbal->shouldReceive('dropColumn')->with('column');
+
+        $this->table->dropColumn('column');
+    }
+}

--- a/tests/Schema/SchemaTableTest.php
+++ b/tests/Schema/SchemaTableTest.php
@@ -218,7 +218,7 @@ class SchemaTableTest extends TestCase
 
     public function test_json()
     {
-        $this->dbal->shouldReceive('addColumn')->with('column', 'json_array');
+        $this->dbal->shouldReceive('addColumn')->with('column', 'json');
         $this->table->json('column');
     }
 


### PR DESCRIPTION
Sadly the blame on lines is now only my name

Also updated the classes:
- Constants have moved to Types
- Require dbal ^2.10.1 because the Types:: constants was introduced here.
- Add mockery back because needed in tests