### PR TITLE
Migrate command: --write-sql default to false

### DIFF
--- a/src/Console/DiffCommand.php
+++ b/src/Console/DiffCommand.php
@@ -18,7 +18,7 @@ class DiffCommand extends BaseCommand
     {--em= : For a specific EntityManager. }
     {--filter-expression= : Tables which are filtered by Regular Expression.}
     {--formatted : Format the generated SQL. }
-    {--line-length=120 : Max line length of unformatted lines.} 
+    {--line-length=120 : Max line length of unformatted lines.}
     {--check-database-platform= : Check Database Platform to the generated code.}
     {--allow-empty-diff : Do not throw an exception when no changes are detected. }
     {--from-empty-schema : Generate a full migration as if the current database was empty. }
@@ -28,6 +28,13 @@ class DiffCommand extends BaseCommand
      * @var string
      */
     protected $description = 'Generate a migration by comparing your current database to your mapping information.';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->getDefinition()->getOption('check-database-platform')->setDefault(false);
+    }
 
     /**
      * Execute the console command.

--- a/src/Console/ExecuteCommand.php
+++ b/src/Console/ExecuteCommand.php
@@ -25,6 +25,13 @@ class ExecuteCommand extends BaseCommand
      */
     protected $description = 'Execute a single migration version up or down manually.';
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->getDefinition()->getOption('write-sql')->setDefault(false);
+    }
+
     /**
      * Execute the console command.
      *

--- a/src/Console/ExecuteCommand.php
+++ b/src/Console/ExecuteCommand.php
@@ -36,6 +36,8 @@ class ExecuteCommand extends BaseCommand
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\ExecuteCommand($dependencyFactory);
 
+        $this->getDefinition()->getOption('write-sql')->setDefault(false);
+
         return $command->run($this->getDoctrineInput($command), $this->output->getOutput());
     }
 }

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -41,6 +41,8 @@ class MigrateCommand extends BaseCommand
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\MigrateCommand($dependencyFactory);
 
+        $this->getDefinition()->getOption('write-sql')->setDefault(false);
+
         return $command->run($this->getDoctrineInput($command), $this->output->getOutput());
     }
 

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaravelDoctrine\Migrations\Console;
 
-use Illuminate\Console\ConfirmableTrait;
 use LaravelDoctrine\Migrations\Configuration\DependencyFactoryProvider;
 
 class MigrateCommand extends BaseCommand
@@ -28,6 +27,13 @@ class MigrateCommand extends BaseCommand
      */
     protected $description = 'Execute a migration to a specified version or the latest available version.';
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->getDefinition()->getOption('write-sql')->setDefault(false);
+    }
+
     /**
      * Execute the console command.
      *
@@ -40,8 +46,6 @@ class MigrateCommand extends BaseCommand
         $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
 
         $command = new \Doctrine\Migrations\Tools\Console\Command\MigrateCommand($dependencyFactory);
-
-        $this->getDefinition()->getOption('write-sql')->setDefault(false);
 
         return $command->run($this->getDoctrineInput($command), $this->output->getOutput());
     }

--- a/tests/CommandConfigurationTest.php
+++ b/tests/CommandConfigurationTest.php
@@ -16,6 +16,7 @@ use function array_keys;
 use function implode;
 use function in_array;
 use function PHPUnit\Framework\assertSame;
+use function print_r;
 
 class CommandConfigurationTest extends \PHPUnit\Framework\TestCase
 {
@@ -65,9 +66,9 @@ class CommandConfigurationTest extends \PHPUnit\Framework\TestCase
 
 
                     // Assert default values matches
-                    if ($theirOption->getDefault() !== false) {
-                        self::assertEquals($ourOption->getDefault(), $theirOption->getDefault(), "Mismatch default value for {$ourCommand->getName()} {$ourOption->getName()}. Their: '{$theirOption->getDefault()}', our: '{$ourOption->getDefault()}'");
-                    }
+                    $theirDefaultValue = var_export($theirOption->getDefault(), true);
+                    $ourDefaultValue = var_export($ourOption->getDefault(), true);
+                    self::assertSame($ourOption->getDefault(), $theirOption->getDefault(), "Mismatch default value for {$ourCommand->getName()} {$ourOption->getName()}. Their: '{$theirDefaultValue}', our: '{$ourDefaultValue}'");
                 }
             }
         }
@@ -76,8 +77,8 @@ class CommandConfigurationTest extends \PHPUnit\Framework\TestCase
         foreach ($ourCommand->getDefinition()->getArguments() as $ourArgument) {
             foreach ($theirCommand->getDefinition()->getArguments() as $theirArgument) {
                 if ($ourArgument->getName() === $theirArgument->getName()) {
-                    $theirDefaultValue = print_r($theirArgument->getDefault(), true);
-                    $ourDefaultValue = print_r($ourArgument->getDefault(), true);
+                    $theirDefaultValue = var_export($theirArgument->getDefault(), true);
+                    $ourDefaultValue = var_export($ourArgument->getDefault(), true);
 
                     if (empty($ourArgument->getDefault()) && empty($theirArgument->getDefault())) {
                         continue;


### PR DESCRIPTION
Set default of write-sql to false to mimic behavior of doctrine/migrations (see https://github.com/doctrine/migrations/blob/5713b45c933122e509d9b31c767b420c3dfed399/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php#L54)

Previously it defaulted to `null` which made the doctrine (upstream) command defaulting to getcwd() (via null-coalesce) and always generating an sql dump