### PR TITLE
WIP: Command for generation failed_jobs table migration

### DIFF
--- a/src/Console/QueueFailedTableCommand.php
+++ b/src/Console/QueueFailedTableCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelDoctrine\Migrations\Console;
+
+use LaravelDoctrine\Migrations\Configuration\DependencyFactoryProvider;
+use LaravelDoctrine\Migrations\DoctrineCommand\GenerateFailedJobsCommand;
+
+class QueueFailedTableCommand extends BaseCommand
+{
+    protected $signature = 'doctrine:migrations:queue-failed-table
+    {--em= : For a specific EntityManager. }
+    {--table=failed_jobs : Name for the table. }';
+
+    protected $description = 'Create a migration for the failed queue jobs database table';
+
+    public function handle(DependencyFactoryProvider $provider): int
+    {
+        $dependencyFactory = $provider->fromEntityManagerName($this->option('em'));
+
+        $command = new GenerateFailedJobsCommand($dependencyFactory);
+
+        return $command->run($this->getDoctrineInput($command), $this->output->getOutput());
+    }
+}

--- a/src/DoctrineCommand/GenerateFailedJobsCommand.php
+++ b/src/DoctrineCommand/GenerateFailedJobsCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelDoctrine\Migrations\DoctrineCommand;
+
+use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use LaravelDoctrine\ORM\Queue\FailedJobTable;
+
+class GenerateFailedJobsCommand extends DoctrineCommand
+{
+    /** @var string|null */
+    protected static $defaultName = 'doctrine:migrations:queue-failed-table';
+
+    protected const UP_TEMPLATE = <<<'UPTEMPLATE'
+$builder = (new \LaravelDoctrine\Migrations\Schema\Builder($schema));
+$builder->create('<tableName>', function (\LaravelDoctrine\Migrations\Schema\Table $table) {
+    $table->increments('id');
+    $table->string('uuid');
+    $table->string('connection');
+    $table->string('queue');
+    $table->text('payload');
+    $table->dateTime('failed_at');
+    $table->text('exception')->setNotnull(false);
+    $table->unique(['uuid'], 'uuid_unique');
+});
+UPTEMPLATE;
+
+    protected const DOWN_TEMPLATE = <<<'DOWN_TEMPLATE'
+$schema->dropTable('<tableName>');
+DOWN_TEMPLATE;
+
+    protected function configure(): void
+    {
+        $this
+            ->setAliases(['failed-table'])
+            ->setDescription('Create a migration for the failed queue jobs database table')
+            ->addOption(
+                'table',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Table name',
+                'failed_jobs'
+            )
+            ->addOption(
+                'namespace',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The namespace to use for the migration (must be in the list of configured namespaces)'
+            );
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $configuration = $this->getDependencyFactory()->getConfiguration();
+
+        $migrationGenerator = $this->getDependencyFactory()->getMigrationGenerator();
+
+        $namespace = $input->getOption('namespace');
+        if ($namespace === '') {
+            $namespace = null;
+        }
+
+        $dirs = $configuration->getMigrationDirectories();
+        if ($namespace === null) {
+            $namespace = key($dirs);
+        } elseif (! isset($dirs[$namespace])) {
+            throw new Exception(sprintf('Path not defined for the namespace %s', $namespace));
+        }
+
+        $tableName = $input->getOption('table');
+
+        assert(is_string($namespace));
+        assert(is_string($tableName));
+
+        $fqcn = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName($namespace);
+
+        $up = $this->upScript($tableName);
+        $down = $this->downScript($tableName);
+        $path = $migrationGenerator->generateMigration($fqcn, $up, $down);
+
+        $this->io->text([
+            sprintf('Generated new migration class to "<info>%s</info>"', $path),
+            '',
+        ]);
+
+        return 0;
+    }
+
+    protected function upScript($tableName): string
+    {
+        return strtr(static::UP_TEMPLATE, [
+            '<tableName>' => $tableName,
+        ]);
+    }
+
+    protected function downScript($tableName): string
+    {
+        return strtr(static::DOWN_TEMPLATE, [
+            '<tableName>' => $tableName,
+        ]);
+    }
+}

--- a/src/MigrationsServiceProvider.php
+++ b/src/MigrationsServiceProvider.php
@@ -20,6 +20,7 @@ use LaravelDoctrine\Migrations\Console\RollbackCommand;
 use LaravelDoctrine\Migrations\Console\StatusCommand;
 use LaravelDoctrine\Migrations\Console\SyncMetadataCommand;
 use LaravelDoctrine\Migrations\Console\VersionCommand;
+use LaravelDoctrine\Migrations\Console\QueueFailedTableCommand;
 
 class MigrationsServiceProvider extends ServiceProvider
 {
@@ -62,7 +63,8 @@ class MigrationsServiceProvider extends ServiceProvider
             GenerateCommand::class,
             SyncMetadataCommand::class,
             ListCommand::class,
-            DumpSchemaCommand::class
+            DumpSchemaCommand::class,
+            QueueFailedTableCommand::class,
         ]);
     }
 


### PR DESCRIPTION
Hello

Please review this idea of providing new command `doctrine:migrations:queue-failed-table` that should replace the default `queue:failed-table`.

Command generates migration for creation of `failed_jobs` used by the internal Laravel Queue package.

We have the [FailedJobsServiceProvider](https://github.com/laravel-doctrine/orm/blob/2.0/src/Queue/FailedJobsServiceProvider.php) in the ORM package, but have very serious downside as it's running query that checks if table exists on each job processing. Some jobs may not need connection to DB, it may slow down job tasks execution.

Basically the perfect case for the `failed_jobs` table to be generated once.
I suggest this solution for the problem.