### PR TITLE
Fixed PHP 8.4 deprecation warnings 

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -27,7 +27,7 @@ class ConfigurationFactory
      * @param string|null $name The EntityManager name
      * @return array<string, mixed> The configuration (see config/migrations.php)
      */
-    public function getConfig(string $name = null): array
+    public function getConfig(?string $name = null): array
     {
         if ($name && $this->config->has('migrations.' . $name)) {
             return $this->config->get('migrations.' . $name, []);
@@ -35,12 +35,12 @@ class ConfigurationFactory
         return $this->config->get('migrations.default', []);
     }
 
-    public function getConfigAsRepository(string $name = null): Repository
+    public function getConfigAsRepository(?string $name = null): Repository
     {
         return new Repository($this->getConfig($name));
     }
 
-    public function make(string $name = null): ConfigurationArray
+    public function make(?string $name = null): ConfigurationArray
     {
         $config = $this->getConfigAsRepository($name);
 

--- a/src/Configuration/DependencyFactoryProvider.php
+++ b/src/Configuration/DependencyFactoryProvider.php
@@ -26,7 +26,7 @@ class DependencyFactoryProvider
      *
      * @return DependencyFactory
      */
-    public function fromEntityManagerName(string $name = null): DependencyFactory
+    public function fromEntityManagerName(?string $name = null): DependencyFactory
     {
         $configuration = $this->factory->make($name);
         return DependencyFactory::fromEntityManager(

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -167,7 +167,7 @@ class Builder
      *
      * @return Table
      */
-    protected function build($table, Closure $callback = null): Table
+    protected function build($table, ?Closure $callback = null): Table
     {
         return new Table($table, $callback);
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -21,7 +21,7 @@ class Table
      * @param Blueprint $table
      * @param Closure|null $callback
      */
-    public function __construct(Blueprint $table, Closure $callback = null)
+    public function __construct(Blueprint $table, ?Closure $callback = null)
     {
         $this->table = $table;
 


### PR DESCRIPTION
Fixed "Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead" warnings.