### PR TITLE
Allow MariaDB to work with ResetCommand

### DIFF
--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -7,6 +7,7 @@ namespace LaravelDoctrine\Migrations\Console;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -35,9 +36,10 @@ class ResetCommand extends BaseCommand
 
     /** @var array<class-string<AbstractPlatform>, string> */
     private const PLATFORM_MAP = [
-        SQLServerPlatform::class => 'mssql',
+        MariaDBPlatform::class => 'mysql',
         MySQLPlatform::class => 'mysql',
         PostgreSQLPlatform::class => 'postgresql',
+        SQLServerPlatform::class => 'mssql',
         SQLitePlatform::class => 'sqlite',
     ];
 


### PR DESCRIPTION
Small fix to allow MariaDB to work with the ResetCommand. MariaDB uses the same cardinality check instructions as MySQL, so we are leaving the name in the PLATFORM_MAP as "mysql" for this reason.