### PR TITLE
fix(ResetCommand): Safely drop sequences/foreignkeys/tables via ->toSQL($platform) 

### DIFF
--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -77,7 +77,7 @@ class ResetCommand extends BaseCommand
         if ($platform->supportsSequences()) {
             $sequences = $schemaManager->introspectSequences();
             foreach ($sequences as $s) {
-                $schemaManager->dropSequence($s->getObjectName()->toString());
+                $schemaManager->dropSequence($s->getObjectName()->toSQL($platform));
             }
         }
 
@@ -85,12 +85,15 @@ class ResetCommand extends BaseCommand
         foreach ($tables as $table) {
             $foreigns = $schemaManager->introspectTableForeignKeyConstraints($table);
             foreach ($foreigns as $f) {
-                $schemaManager->dropForeignKey($f->getObjectName()->toString(), $table->toString());
+                $schemaManager->dropForeignKey(
+                    $f->getObjectName()->toSQL($platform),
+                    $table->toSQL($platform)
+                );
             }
         }
 
         foreach ($tables as $table) {
-            $this->safelyDropTable($table->toString());
+            $this->safelyDropTable($table->toSQL($platform));
         }
     }
 

--- a/tests/ResetCommandTest.php
+++ b/tests/ResetCommandTest.php
@@ -1,96 +1,74 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelDoctrine\Migrations\Tests;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Name\Identifier as NameIdentifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\Migrations\DependencyFactory;
 use LaravelDoctrine\Migrations\Configuration\DependencyFactoryProvider;
 use LaravelDoctrine\Migrations\Console\ResetCommand;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 
 class ResetCommandTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
+    use MockeryPHPUnitIntegration;
 
-    public function testItQuotesDbal4NamesWhenResetting(): void
+    /**
+     * @var m\MockInterface|Connection
+     */
+    protected $connection;
+
+    /**
+     * @var m\MockInterface|AbstractSchemaManager
+     */
+    protected $schemaManager;
+
+    /**
+     * @var m\MockInterface|DependencyFactory
+     */
+    protected $dependencyFactory;
+
+    /**
+     * @var m\MockInterface|DependencyFactoryProvider
+     */
+    protected $provider;
+
+    /**
+     * @var ResetCommand
+     */
+    protected $command;
+
+    protected MySQLPlatform $platform;
+
+    /**
+     * @var list<string>
+     */
+    protected array $executed;
+
+    protected function setUp(): void
     {
-        $platform = new class extends MySQLPlatform {
+        $this->executed = [];
+
+        $this->platform = new class extends MySQLPlatform {
             public function supportsSequences(): bool
             {
                 return true;
             }
         };
 
-        $sequenceName = OptionallyQualifiedName::unquoted('seq1');
-        $tableName    = OptionallyQualifiedName::unquoted('access_codes');
-        $foreignName  = NameIdentifier::unquoted('FK_TEST');
+        $this->connection        = m::mock(Connection::class);
+        $this->schemaManager     = m::mock(AbstractSchemaManager::class);
+        $this->dependencyFactory = m::mock(DependencyFactory::class);
+        $this->provider          = m::mock(DependencyFactoryProvider::class);
 
-        $executed = [];
-
-        $connection = m::mock(Connection::class);
-        $connection->shouldReceive('getDatabasePlatform')->andReturn($platform);
-        $connection->shouldReceive('executeStatement')->andReturnUsing(function (string $sql) use (&$executed) {
-            $executed[] = $sql;
-            return 0;
-        });
-
-        $schemaManager = m::mock(AbstractSchemaManager::class);
-        $schemaManager->shouldReceive('introspectSequences')->andReturn([
-            new class ($sequenceName) {
-                public function __construct(private OptionallyQualifiedName $name)
-                {
-                }
-
-                public function getObjectName(): OptionallyQualifiedName
-                {
-                    return $this->name;
-                }
-            }
-        ]);
-
-        $schemaManager->shouldReceive('introspectTableNames')->andReturn([$tableName]);
-
-        $schemaManager->shouldReceive('introspectTableForeignKeyConstraints')->andReturn([
-            new class ($foreignName) {
-                public function __construct(private NameIdentifier $name)
-                {
-                }
-
-                public function getObjectName(): NameIdentifier
-                {
-                    return $this->name;
-                }
-            }
-        ]);
-
-        $schemaManager->shouldReceive('dropSequence')->andReturnUsing(function (string $sequence) use ($connection) {
-            $connection->executeStatement(sprintf('DROP SEQUENCE %s', $sequence));
-        });
-
-        $schemaManager->shouldReceive('dropForeignKey')->andReturnUsing(function (string $fk, string $table) use ($connection) {
-            $connection->executeStatement(sprintf('ALTER TABLE %s DROP FOREIGN KEY %s', $table, $fk));
-        });
-
-        $schemaManager->shouldReceive('dropTable')->andReturnUsing(function (string $table) use ($connection) {
-            $connection->executeStatement(sprintf('DROP TABLE %s', $table));
-        });
-        $connection->shouldReceive('createSchemaManager')->andReturn($schemaManager, $schemaManager);
-
-        $dependencyFactory = m::mock(DependencyFactory::class);
-        $dependencyFactory->shouldReceive('getConnection')->andReturn($connection);
-
-        $provider = m::mock(DependencyFactoryProvider::class);
-        $provider->shouldReceive('fromEntityManagerName')->with(null)->andReturn($dependencyFactory);
-
-        $command = new class extends ResetCommand {
+        $this->command = new class extends ResetCommand {
             public function confirmToProceed($warning = 'Application In Production!', $callback = null): bool
             {
                 return true;
@@ -105,8 +83,102 @@ class ResetCommandTest extends TestCase
             {
             }
         };
+    }
 
-        $command->handle($provider);
+    public function testItQuotesDbal4NamesWhenResetting(): void
+    {
+        $sequenceName = OptionallyQualifiedName::unquoted('seq1');
+        $tableName    = OptionallyQualifiedName::unquoted('access_codes');
+        $foreignName  = NameIdentifier::unquoted('FK_TEST');
+
+        $this->connection->shouldReceive('getDatabasePlatform')
+            ->atLeast()->once()
+            ->andReturn($this->platform);
+
+        $this->connection->shouldReceive('executeStatement')
+            ->times(5)
+            ->andReturnUsing(function (string $sql): int {
+                $this->executed[] = $sql;
+                return 0;
+            });
+
+        $this->connection->shouldReceive('createSchemaManager')
+            ->twice()
+            ->andReturn($this->schemaManager, $this->schemaManager);
+
+        $this->schemaManager->shouldReceive('introspectSequences')
+            ->once()
+            ->andReturn([
+                new class ($sequenceName) {
+                    public function __construct(private OptionallyQualifiedName $name)
+                    {
+                    }
+
+                    public function getObjectName(): OptionallyQualifiedName
+                    {
+                        return $this->name;
+                    }
+                }
+            ]);
+
+        $this->schemaManager->shouldReceive('introspectTableNames')
+            ->once()
+            ->andReturn([$tableName]);
+
+        $this->schemaManager->shouldReceive('introspectTableForeignKeyConstraints')
+            ->with($tableName)
+            ->once()
+            ->andReturn([
+                new class ($foreignName) {
+                    public function __construct(private NameIdentifier $name)
+                    {
+                    }
+
+                    public function getObjectName(): NameIdentifier
+                    {
+                        return $this->name;
+                    }
+                }
+            ]);
+
+        $this->schemaManager->shouldReceive('dropSequence')
+            ->once()
+            ->withArgs(function (string $sequence): bool {
+                self::assertSame('`seq1`', $sequence);
+                return true;
+            })
+            ->andReturnUsing(function (string $sequence): void {
+                $this->connection->executeStatement(sprintf('DROP SEQUENCE %s', $sequence));
+            });
+
+        $this->schemaManager->shouldReceive('dropForeignKey')
+            ->once()
+            ->withArgs(function (string $fk, string $table): bool {
+                self::assertSame('`FK_TEST`', $fk);
+                self::assertSame('`access_codes`', $table);
+                return true;
+            })
+            ->andReturnUsing(function (string $fk, string $table): void {
+                $this->connection->executeStatement(sprintf('ALTER TABLE %s DROP FOREIGN KEY %s', $table, $fk));
+            });
+
+        $this->schemaManager->shouldReceive('dropTable')
+            ->once()
+            ->with('`access_codes`')
+            ->andReturnUsing(function (string $table): void {
+                $this->connection->executeStatement(sprintf('DROP TABLE %s', $table));
+            });
+
+        $this->dependencyFactory->shouldReceive('getConnection')
+            ->once()
+            ->andReturn($this->connection);
+
+        $this->provider->shouldReceive('fromEntityManagerName')
+            ->with(null)
+            ->once()
+            ->andReturn($this->dependencyFactory);
+
+        $this->command->handle($this->provider);
 
         self::assertSame([
             'DROP SEQUENCE `seq1`',
@@ -114,6 +186,6 @@ class ResetCommandTest extends TestCase
             'SET FOREIGN_KEY_CHECKS = 0',
             'DROP TABLE `access_codes`',
             'SET FOREIGN_KEY_CHECKS = 1',
-        ], $executed);
+        ], $this->executed);
     }
 }

--- a/tests/ResetCommandTest.php
+++ b/tests/ResetCommandTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace LaravelDoctrine\Migrations\Tests;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Name\Identifier as NameIdentifier;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\Migrations\DependencyFactory;
+use LaravelDoctrine\Migrations\Configuration\DependencyFactoryProvider;
+use LaravelDoctrine\Migrations\Console\ResetCommand;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ResetCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testItQuotesDbal4NamesWhenResetting(): void
+    {
+        $platform = new class extends MySQLPlatform {
+            public function supportsSequences(): bool
+            {
+                return true;
+            }
+        };
+
+        $sequenceName = OptionallyQualifiedName::unquoted('seq1');
+        $tableName    = OptionallyQualifiedName::unquoted('access_codes');
+        $foreignName  = NameIdentifier::unquoted('FK_TEST');
+
+        $executed = [];
+
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getDatabasePlatform')->andReturn($platform);
+        $connection->shouldReceive('executeStatement')->andReturnUsing(function (string $sql) use (&$executed) {
+            $executed[] = $sql;
+            return 0;
+        });
+
+        $schemaManager = m::mock(AbstractSchemaManager::class);
+        $schemaManager->shouldReceive('introspectSequences')->andReturn([
+            new class ($sequenceName) {
+                public function __construct(private OptionallyQualifiedName $name)
+                {
+                }
+
+                public function getObjectName(): OptionallyQualifiedName
+                {
+                    return $this->name;
+                }
+            }
+        ]);
+
+        $schemaManager->shouldReceive('introspectTableNames')->andReturn([$tableName]);
+
+        $schemaManager->shouldReceive('introspectTableForeignKeyConstraints')->andReturn([
+            new class ($foreignName) {
+                public function __construct(private NameIdentifier $name)
+                {
+                }
+
+                public function getObjectName(): NameIdentifier
+                {
+                    return $this->name;
+                }
+            }
+        ]);
+
+        $schemaManager->shouldReceive('dropSequence')->andReturnUsing(function (string $sequence) use ($connection) {
+            $connection->executeStatement(sprintf('DROP SEQUENCE %s', $sequence));
+        });
+
+        $schemaManager->shouldReceive('dropForeignKey')->andReturnUsing(function (string $fk, string $table) use ($connection) {
+            $connection->executeStatement(sprintf('ALTER TABLE %s DROP FOREIGN KEY %s', $table, $fk));
+        });
+
+        $schemaManager->shouldReceive('dropTable')->andReturnUsing(function (string $table) use ($connection) {
+            $connection->executeStatement(sprintf('DROP TABLE %s', $table));
+        });
+        $connection->shouldReceive('createSchemaManager')->andReturn($schemaManager, $schemaManager);
+
+        $dependencyFactory = m::mock(DependencyFactory::class);
+        $dependencyFactory->shouldReceive('getConnection')->andReturn($connection);
+
+        $provider = m::mock(DependencyFactoryProvider::class);
+        $provider->shouldReceive('fromEntityManagerName')->with(null)->andReturn($dependencyFactory);
+
+        $command = new class extends ResetCommand {
+            public function confirmToProceed($warning = 'Application In Production!', $callback = null): bool
+            {
+                return true;
+            }
+
+            public function option($key = null)
+            {
+                return null;
+            }
+
+            public function info($string, $verbosity = null): void
+            {
+            }
+        };
+
+        $command->handle($provider);
+
+        self::assertSame([
+            'DROP SEQUENCE `seq1`',
+            'ALTER TABLE `access_codes` DROP FOREIGN KEY `FK_TEST`',
+            'SET FOREIGN_KEY_CHECKS = 0',
+            'DROP TABLE `access_codes`',
+            'SET FOREIGN_KEY_CHECKS = 1',
+        ], $executed);
+    }
+}


### PR DESCRIPTION
In upgrading `laravel-doctrine/migrations` we ran into issues with the `ResetCommand` and `MySQL`. 

The current implementation was writing queries against the `migrations` table without properly wrapping the table name in quotes. IIRC this is required in MySQL because `migrations` is a reserved word. The `->toSQL($platform)` is more robust than `->toString()` because it takes these platform quirks into account. 

I've also added an automated test for the `ResetCommand` to make sure this behaviour is being followed. This test was written by Claude Code. It seems...fine? I can see that it is testing, but the amount of mocking going makes me a bit uneasy.I would not be offended if you wanted to remove it or re-write it significantly. 

Note: This is not urgent _for me_ as we have just copied the `ResetCommand` into our repo and made the necessary changes to get our CI passing again. 